### PR TITLE
Fix minor typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ k6build cache [flags]
 ```
 
 # start the cache server serving an external url
-k6build cache --download0url http://external.url
+k6build cache --download-url http://external.url
 
 # store object from same host
 curl -x POST http://localhost:9000/cache/objectID -d "object content" | jq .

--- a/build.go
+++ b/build.go
@@ -1,4 +1,4 @@
-// Package k6build defines a service for building k8 binaries
+// Package k6build defines a service for building k6 binaries
 package k6build
 
 import (
@@ -21,7 +21,7 @@ type Dependency struct {
 // Module defines an artifact dependency
 type Module struct {
 	Path    string `json:"path,omitempty"`
-	Version string `json:"vesion,omitempty"`
+	Version string `json:"version,omitempty"`
 }
 
 // Artifact defines a binary that can be downloaded

--- a/pkg/cache/file/file.go
+++ b/pkg/cache/file/file.go
@@ -141,7 +141,7 @@ func (f *Cache) Download(_ context.Context, object cache.Object) (io.ReadCloser,
 
 		objectFile, err := os.Open(objectPath) //nolint:gosec // path is sanitized
 		if err != nil {
-			// FIXE: is the path has invalid characters, still will return ErrNotExists
+			// FIXME: is the path has invalid characters, still will return ErrNotExists
 			if errors.Is(err, os.ErrNotExist) {
 				return nil, cache.ErrObjectNotFound
 			}

--- a/pkg/local/local.go
+++ b/pkg/local/local.go
@@ -36,7 +36,7 @@ type BuildServiceConfig struct {
 	CacheDir string
 	// Copy go environment. BuildEnv can override the variables copied from go environment.
 	CopyGoEnv bool
-	// ser verbose build mode
+	// set verbose build mode
 	Verbose bool
 }
 


### PR DESCRIPTION
# What?

This fixes some types that I've spotted.

One of the typos was in a serialization of the exported struct, but I hope that's fine combining this within a single PR