### PR TITLE
Return error reason

### DIFF
--- a/cmd/local/local.go
+++ b/cmd/local/local.go
@@ -2,7 +2,6 @@
 package local
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -15,8 +14,6 @@ import (
 
 	"github.com/spf13/cobra"
 )
-
-var ErrTargetPlatformUndefined = errors.New("target platform is required") //nolint:revive
 
 const (
 	long = `

--- a/error.go
+++ b/error.go
@@ -6,9 +6,6 @@ import (
 	"fmt"
 )
 
-// ErrReasonUnknown signals the reason for an APIError in unknown
-var ErrReasonUnknown = errors.New("reason unknown")
-
 // Error represents an error returned by the build service
 // This custom error type facilitates extracting the reason of an error
 // by using errors.Unwrap method.
@@ -24,7 +21,11 @@ type Error struct {
 
 // Error returns the Error as a string
 func (e *Error) Error() string {
-	return fmt.Sprintf("%s: %s", e.Err, e.Reason)
+	reason := ""
+	if e.Reason != nil {
+		reason = fmt.Sprintf(": %s", e.Reason)
+	}
+	return fmt.Sprintf("%s%s", e.Err, reason)
 }
 
 // Is returns true if the target error is the same as the Error or its reason
@@ -63,12 +64,16 @@ func (e *Error) Unwrap() error {
 
 // MarshalJSON implements the json.Marshaler interface for the Error type
 func (e *Error) MarshalJSON() ([]byte, error) {
+	reason := ""
+	if e.Reason != nil {
+		reason = e.Reason.Error()
+	}
 	return json.Marshal(&struct {
 		Err    string `json:"error,omitempty"`
 		Reason string `json:"reason,omitempty"`
 	}{
 		Err:    e.Err.Error(),
-		Reason: e.Reason.Error(),
+		Reason: reason,
 	})
 }
 
@@ -91,7 +96,7 @@ func (e *Error) UnmarshalJSON(data []byte) error {
 // NewError creates an Error from an error and a reason
 // If the reason is nil, ErrReasonUnknown is used
 func NewError(err error, reasons ...error) *Error {
-	reason := ErrReasonUnknown
+	var reason error
 	if len(reasons) > 0 {
 		reason = NewError(reasons[0], reasons[1:]...)
 	}

--- a/error.go
+++ b/error.go
@@ -90,9 +90,10 @@ func (e *Error) UnmarshalJSON(data []byte) error {
 
 // NewError creates an Error from an error and a reason
 // If the reason is nil, ErrReasonUnknown is used
-func NewError(err error, reason error) *Error {
-	if reason == nil {
-		reason = ErrReasonUnknown
+func NewError(err error, reasons ...error) *Error {
+	reason := ErrReasonUnknown
+	if len(reasons) > 0 {
+		reason = NewError(reasons[0], reasons[1:]...)
 	}
 	return &Error{
 		Err:    err,

--- a/error.go
+++ b/error.go
@@ -1,0 +1,101 @@
+package k6build
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// ErrReasonUnknown signals the reason for an APIError in unknown
+var ErrReasonUnknown = errors.New("reason unknown")
+
+// Error represents an error returned by the build service
+// This custom error type facilitates extracting the reason of an error
+// by using errors.Unwrap method.
+// It also facilitates checking an error (or its reason) using errors.Is by
+// comparing the error and its reason.
+// This custom type has the following known limitations:
+// - A nil Error 'e' will not satisfy errors.Is(e, nil)
+// - Is method will not
+type Error struct {
+	Err    error `json:"error,omitempty"`
+	Reason error `json:"reason,omitempty"`
+}
+
+// Error returns the Error as a string
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s: %s", e.Err, e.Reason)
+}
+
+// Is returns true if the target error is the same as the Error or its reason
+// It attempts several strategies:
+// - compare error and reason to target's Error()
+// - unwrap the error and reason and compare to target's Error
+// - unwrap target and compares to the error recursively
+func (e *Error) Is(target error) bool {
+	if target == nil {
+		return false
+	}
+
+	if e.Err.Error() == target.Error() {
+		return true
+	}
+
+	if e.Reason != nil && e.Reason.Error() == target.Error() {
+		return true
+	}
+
+	if u := errors.Unwrap(e.Err); u != nil && u.Error() == target.Error() {
+		return true
+	}
+
+	if u := errors.Unwrap(e.Reason); u != nil && u.Error() == target.Error() {
+		return true
+	}
+
+	return e.Is(errors.Unwrap(target))
+}
+
+// Unwrap returns the underlying reason for the Error
+func (e *Error) Unwrap() error {
+	return e.Reason
+}
+
+// MarshalJSON implements the json.Marshaler interface for the Error type
+func (e *Error) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Err    string `json:"error,omitempty"`
+		Reason string `json:"reason,omitempty"`
+	}{
+		Err:    e.Err.Error(),
+		Reason: e.Reason.Error(),
+	})
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for the Error type
+func (e *Error) UnmarshalJSON(data []byte) error {
+	val := struct {
+		Err    string `json:"error,omitempty"`
+		Reason string `json:"reason,omitempty"`
+	}{}
+
+	if err := json.Unmarshal(data, &val); err != nil {
+		return err
+	}
+
+	e.Err = errors.New(val.Err)
+	e.Reason = errors.New(val.Reason)
+	return nil
+}
+
+// NewError creates an Error from an error and a reason
+// If the reason is nil, ErrReasonUnknown is used
+func NewError(err error, reason error) *Error {
+	if reason == nil {
+		reason = ErrReasonUnknown
+	}
+	return &Error{
+		Err:    err,
+		Reason: reason,
+	}
+}

--- a/error_test.go
+++ b/error_test.go
@@ -6,62 +6,62 @@ import (
 	"testing"
 )
 
-func Test_APIError(t *testing.T) {
+func Test_Error(t *testing.T) {
 	t.Parallel()
 
 	var (
-		err    = errors.New("error")
-		reason = errors.New("reason")
+		err     = errors.New("error")
+		reason  = errors.New("reason")
+		another = errors.New("another reason")
 	)
 
 	testCases := []struct {
-		title        string
-		err          error
-		reason       error
-		expectError  error
-		expectReason error
+		title   string
+		err     error
+		reasons []error
+		expect  []error
 	}{
 		{
-			title:        "error and reason",
-			err:          err,
-			reason:       reason,
-			expectError:  err,
-			expectReason: reason,
+			title:   "error and reason",
+			err:     err,
+			reasons: []error{reason},
+			expect:  []error{err, reason},
 		},
 		{
-			title:        "error not reason",
-			err:          err,
-			reason:       nil,
-			expectError:  err,
-			expectReason: ErrReasonUnknown,
+			title:   "error not reason",
+			err:     err,
+			reasons: nil,
+			expect:  []error{err},
 		},
 		{
-			title:        "wrapped err",
-			err:          fmt.Errorf("wrapped %w", err),
-			reason:       reason,
-			expectError:  err,
-			expectReason: reason,
+			title:   "multiple and reasons",
+			err:     err,
+			reasons: []error{reason, another},
+			expect:  []error{err, reason, another},
 		},
 		{
-			title:        "wrapped reason",
-			err:          errors.New("another error"),
-			reason:       fmt.Errorf("wrapped %w", reason),
-			expectError:  reason,
-			expectReason: reason,
+			title:   "wrapped err",
+			err:     fmt.Errorf("wrapped %w", err),
+			reasons: []error{reason},
+			expect:  []error{err, reason},
 		},
 		{
-			title:        "wrapped err in target",
-			err:          err,
-			reason:       reason,
-			expectError:  fmt.Errorf("wrapped %w", err),
-			expectReason: reason,
+			title:   "wrapped reason",
+			err:     err,
+			reasons: []error{fmt.Errorf("wrapped %w", reason)},
+			expect:  []error{err, reason},
 		},
 		{
-			title:        "wrapped reason in target",
-			err:          err,
-			reason:       reason,
-			expectError:  fmt.Errorf("wrapped %w", reason),
-			expectReason: reason,
+			title:   "wrapped err in target",
+			err:     err,
+			reasons: []error{reason},
+			expect:  []error{fmt.Errorf("wrapped %w", err)},
+		},
+		{
+			title:   "wrapped reason in target",
+			err:     err,
+			reasons: []error{reason},
+			expect:  []error{fmt.Errorf("wrapped %w", reason)},
 		},
 	}
 
@@ -69,14 +69,11 @@ func Test_APIError(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			t.Parallel()
 
-			apiError := NewError(tc.err, tc.reason)
-
-			if !errors.Is(apiError, tc.expectError) {
-				t.Fatalf("expected %v got %v", tc.expectError, apiError)
-			}
-
-			if !errors.Is(errors.Unwrap(apiError), tc.expectReason) {
-				t.Fatalf("expected %v got %v", tc.expectError, apiError)
+			err := NewError(tc.err, tc.reasons...)
+			for _, expected := range tc.expect {
+				if !errors.Is(err, expected) {
+					t.Fatalf("expected %v got %v", expected, err)
+				}
 			}
 		})
 	}

--- a/error_test.go
+++ b/error_test.go
@@ -10,58 +10,57 @@ func Test_Error(t *testing.T) {
 	t.Parallel()
 
 	var (
-		err     = errors.New("error")
-		reason  = errors.New("reason")
-		another = errors.New("another reason")
+		err    = errors.New("error")
+		reason = errors.New("reason")
 	)
 
 	testCases := []struct {
-		title   string
-		err     error
-		reasons []error
-		expect  []error
+		title  string
+		err    error
+		reason error
+		expect []error
 	}{
 		{
-			title:   "error and reason",
-			err:     err,
-			reasons: []error{reason},
-			expect:  []error{err, reason},
+			title:  "error and reason",
+			err:    err,
+			reason: reason,
+			expect: []error{err, reason},
 		},
 		{
-			title:   "error not reason",
-			err:     err,
-			reasons: nil,
-			expect:  []error{err},
+			title:  "error not reason",
+			err:    err,
+			reason: nil,
+			expect: []error{err},
 		},
 		{
-			title:   "multiple and reasons",
-			err:     err,
-			reasons: []error{reason, another},
-			expect:  []error{err, reason, another},
+			title:  "multiple and reasons",
+			err:    err,
+			reason: reason,
+			expect: []error{err, reason},
 		},
 		{
-			title:   "wrapped err",
-			err:     fmt.Errorf("wrapped %w", err),
-			reasons: []error{reason},
-			expect:  []error{err, reason},
+			title:  "wrapped err",
+			err:    fmt.Errorf("wrapped %w", err),
+			reason: reason,
+			expect: []error{err, reason},
 		},
 		{
-			title:   "wrapped reason",
-			err:     err,
-			reasons: []error{fmt.Errorf("wrapped %w", reason)},
-			expect:  []error{err, reason},
+			title:  "wrapped reason",
+			err:    err,
+			reason: fmt.Errorf("wrapped %w", reason),
+			expect: []error{err, reason},
 		},
 		{
-			title:   "wrapped err in target",
-			err:     err,
-			reasons: []error{reason},
-			expect:  []error{fmt.Errorf("wrapped %w", err)},
+			title:  "wrapped err in target",
+			err:    err,
+			reason: reason,
+			expect: []error{fmt.Errorf("wrapped %w", err)},
 		},
 		{
-			title:   "wrapped reason in target",
-			err:     err,
-			reasons: []error{reason},
-			expect:  []error{fmt.Errorf("wrapped %w", reason)},
+			title:  "wrapped reason in target",
+			err:    err,
+			reason: reason,
+			expect: []error{fmt.Errorf("wrapped %w", reason)},
 		},
 	}
 
@@ -69,7 +68,7 @@ func Test_Error(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			t.Parallel()
 
-			err := NewError(tc.err, tc.reasons...)
+			err := NewError(tc.err, tc.reason)
 			for _, expected := range tc.expect {
 				if !errors.Is(err, expected) {
 					t.Fatalf("expected %v got %v", expected, err)

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,83 @@
+package k6build
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func Test_APIError(t *testing.T) {
+	t.Parallel()
+
+	var (
+		err    = errors.New("error")
+		reason = errors.New("reason")
+	)
+
+	testCases := []struct {
+		title        string
+		err          error
+		reason       error
+		expectError  error
+		expectReason error
+	}{
+		{
+			title:        "error and reason",
+			err:          err,
+			reason:       reason,
+			expectError:  err,
+			expectReason: reason,
+		},
+		{
+			title:        "error not reason",
+			err:          err,
+			reason:       nil,
+			expectError:  err,
+			expectReason: ErrReasonUnknown,
+		},
+		{
+			title:        "wrapped err",
+			err:          fmt.Errorf("wrapped %w", err),
+			reason:       reason,
+			expectError:  err,
+			expectReason: reason,
+		},
+		{
+			title:        "wrapped reason",
+			err:          errors.New("another error"),
+			reason:       fmt.Errorf("wrapped %w", reason),
+			expectError:  reason,
+			expectReason: reason,
+		},
+		{
+			title:        "wrapped err in target",
+			err:          err,
+			reason:       reason,
+			expectError:  fmt.Errorf("wrapped %w", err),
+			expectReason: reason,
+		},
+		{
+			title:        "wrapped reason in target",
+			err:          err,
+			reason:       reason,
+			expectError:  fmt.Errorf("wrapped %w", reason),
+			expectReason: reason,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
+			apiError := NewError(tc.err, tc.reason)
+
+			if !errors.Is(apiError, tc.expectError) {
+				t.Fatalf("expected %v got %v", tc.expectError, apiError)
+			}
+
+			if !errors.Is(errors.Unwrap(apiError), tc.expectReason) {
+				t.Fatalf("expected %v got %v", tc.expectError, apiError)
+			}
+		})
+	}
+}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -3,9 +3,20 @@ package api
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	"github.com/grafana/k6build"
+)
+
+var (
+	// ErrInvalidRequest signals the request could not be processed
+	// due to erroneous parameters
+	ErrInvalidRequest = errors.New("invalid request")
+	// ErrRequestFailed signals the request failed, probably due to a network error
+	ErrRequestFailed = errors.New("request failed")
+	// ErrBuildFailed signals the build process failed
+	ErrBuildFailed = errors.New("build failed")
 )
 
 // BuildRequest defines a request to the build service
@@ -28,6 +39,10 @@ func (r BuildRequest) String() string {
 
 // BuildResponse defines the response for a BuildRequest
 type BuildResponse struct {
-	Error    string           `json:"error,omitempty"`
+	// If not empty an error occurred processing the request
+	// This Error can be compared to the errors defined in this package using errors.Is
+	// to know the type of error, and use Unwrap to obtain its cause if available.
+	Error *k6build.Error `json:"error,omitempty"`
+	// Artifact metadata. If an error occurred, content is undefined
 	Artifact k6build.Artifact `json:"artifact,omitempty"`
 }

--- a/pkg/cache/api/api.go
+++ b/pkg/cache/api/api.go
@@ -2,8 +2,20 @@
 package api
 
 import (
+	"errors"
+
 	"github.com/grafana/k6build"
 	"github.com/grafana/k6build/pkg/cache"
+)
+
+var (
+	// ErrInvalidRequest signals the request could not be processed
+	// due to erroneous parameters
+	ErrInvalidRequest = errors.New("invalid request")
+	// ErrRequestFailed signals the request failed, probably due to a network error
+	ErrRequestFailed = errors.New("request failed")
+	// ErrCacheAccess signals the access to the cache failed
+	ErrCacheAccess = errors.New("cache access failed")
 )
 
 // CacheResponse is the response to a cache server request

--- a/pkg/cache/api/api.go
+++ b/pkg/cache/api/api.go
@@ -2,11 +2,12 @@
 package api
 
 import (
+	"github.com/grafana/k6build"
 	"github.com/grafana/k6build/pkg/cache"
 )
 
 // CacheResponse is the response to a cache server request
 type CacheResponse struct {
-	Error  string
+	Error  *k6build.Error
 	Object cache.Object
 }

--- a/pkg/cache/client/client_test.go
+++ b/pkg/cache/client/client_test.go
@@ -73,7 +73,7 @@ func TestCacheClientGet(t *testing.T) {
 			title:  "error accessing object",
 			status: http.StatusInternalServerError,
 			resp: &api.CacheResponse{
-				Error:  k6build.NewError(cache.ErrAccessingObject),
+				Error:  k6build.NewError(cache.ErrAccessingObject, nil),
 				Object: cache.Object{},
 			},
 			expectErr: ErrRequestFailed,
@@ -121,7 +121,7 @@ func TestCacheClientStore(t *testing.T) {
 			title:  "error creating object",
 			status: http.StatusInternalServerError,
 			resp: &api.CacheResponse{
-				Error:  k6build.NewError(cache.ErrCreatingObject),
+				Error:  k6build.NewError(cache.ErrCreatingObject, nil),
 				Object: cache.Object{},
 			},
 			expectErr: ErrRequestFailed,

--- a/pkg/cache/client/client_test.go
+++ b/pkg/cache/client/client_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/grafana/k6build"
 	"github.com/grafana/k6build/pkg/cache"
 	"github.com/grafana/k6build/pkg/cache/api"
 )
@@ -58,7 +59,7 @@ func TestCacheClientGet(t *testing.T) {
 			title:  "normal get",
 			status: http.StatusOK,
 			resp: &api.CacheResponse{
-				Error:  "",
+				Error:  nil,
 				Object: cache.Object{},
 			},
 		},
@@ -72,7 +73,7 @@ func TestCacheClientGet(t *testing.T) {
 			title:  "error accessing object",
 			status: http.StatusInternalServerError,
 			resp: &api.CacheResponse{
-				Error:  "Error accessing object",
+				Error:  k6build.NewError(cache.ErrAccessingObject),
 				Object: cache.Object{},
 			},
 			expectErr: ErrRequestFailed,
@@ -112,7 +113,7 @@ func TestCacheClientStore(t *testing.T) {
 			title:  "normal response",
 			status: http.StatusOK,
 			resp: &api.CacheResponse{
-				Error:  "",
+				Error:  nil,
 				Object: cache.Object{},
 			},
 		},
@@ -120,7 +121,7 @@ func TestCacheClientStore(t *testing.T) {
 			title:  "error creating object",
 			status: http.StatusInternalServerError,
 			resp: &api.CacheResponse{
-				Error:  "Error creating object",
+				Error:  k6build.NewError(cache.ErrCreatingObject),
 				Object: cache.Object{},
 			},
 			expectErr: ErrRequestFailed,

--- a/pkg/cache/client/client_test.go
+++ b/pkg/cache/client/client_test.go
@@ -73,10 +73,10 @@ func TestCacheClientGet(t *testing.T) {
 			title:  "error accessing object",
 			status: http.StatusInternalServerError,
 			resp: &api.CacheResponse{
-				Error:  k6build.NewError(cache.ErrAccessingObject, nil),
+				Error:  k6build.NewError(cache.ErrAccessingObject, k6build.ErrReasonUnknown),
 				Object: cache.Object{},
 			},
-			expectErr: ErrRequestFailed,
+			expectErr: api.ErrRequestFailed,
 		},
 	}
 
@@ -121,10 +121,10 @@ func TestCacheClientStore(t *testing.T) {
 			title:  "error creating object",
 			status: http.StatusInternalServerError,
 			resp: &api.CacheResponse{
-				Error:  k6build.NewError(cache.ErrCreatingObject, nil),
+				Error:  k6build.NewError(cache.ErrCreatingObject, k6build.ErrReasonUnknown),
 				Object: cache.Object{},
 			},
-			expectErr: ErrRequestFailed,
+			expectErr: api.ErrRequestFailed,
 		},
 	}
 
@@ -165,7 +165,7 @@ func TestCacheClientDownload(t *testing.T) {
 		{
 			title:     "error creating object",
 			status:    http.StatusInternalServerError,
-			expectErr: ErrRequestFailed,
+			expectErr: api.ErrRequestFailed,
 		},
 	}
 

--- a/pkg/cache/server/server.go
+++ b/pkg/cache/server/server.go
@@ -67,7 +67,7 @@ func (s *CacheServer) Get(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		resp.Error = k6build.NewError(ErrInvalidRequest)
+		resp.Error = k6build.NewError(ErrInvalidRequest, nil)
 		s.log.Error(resp.Error.Error())
 		_ = json.NewEncoder(w).Encode(resp) //nolint:errchkjson
 		return
@@ -82,7 +82,7 @@ func (s *CacheServer) Get(w http.ResponseWriter, r *http.Request) {
 			s.log.Error(err.Error())
 			w.WriteHeader(http.StatusInternalServerError)
 		}
-		resp.Error = k6build.NewError(err)
+		resp.Error = k6build.NewError(err, nil)
 		_ = json.NewEncoder(w).Encode(resp) //nolint:errchkjson
 
 		return
@@ -123,7 +123,7 @@ func (s *CacheServer) Store(w http.ResponseWriter, r *http.Request) {
 	object, err := s.cache.Store(context.Background(), id, r.Body) //nolint:contextcheck
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		resp.Error = k6build.NewError(err)
+		resp.Error = k6build.NewError(err, nil)
 		return
 	}
 

--- a/pkg/cache/server/server.go
+++ b/pkg/cache/server/server.go
@@ -15,8 +15,6 @@ import (
 	"github.com/grafana/k6build/pkg/cache/api"
 )
 
-var ErrInvalidRequest = errors.New("invalid request") //nolint:revive
-
 // CacheServer implements an http server that handles cache requests
 type CacheServer struct {
 	baseURL string
@@ -67,7 +65,7 @@ func (s *CacheServer) Get(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		resp.Error = k6build.NewError(ErrInvalidRequest, nil)
+		resp.Error = k6build.NewError(api.ErrInvalidRequest, fmt.Errorf("object id is required"))
 		s.log.Error(resp.Error.Error())
 		_ = json.NewEncoder(w).Encode(resp) //nolint:errchkjson
 		return
@@ -82,7 +80,7 @@ func (s *CacheServer) Get(w http.ResponseWriter, r *http.Request) {
 			s.log.Error(err.Error())
 			w.WriteHeader(http.StatusInternalServerError)
 		}
-		resp.Error = k6build.NewError(err, nil)
+		resp.Error = k6build.NewError(api.ErrCacheAccess, err)
 		_ = json.NewEncoder(w).Encode(resp) //nolint:errchkjson
 
 		return
@@ -116,14 +114,14 @@ func (s *CacheServer) Store(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		resp.Error = k6build.NewError(ErrInvalidRequest, fmt.Errorf("object id is required"))
+		resp.Error = k6build.NewError(api.ErrInvalidRequest, fmt.Errorf("object id is required"))
 		return
 	}
 
 	object, err := s.cache.Store(context.Background(), id, r.Body) //nolint:contextcheck
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		resp.Error = k6build.NewError(err, nil)
+		resp.Error = k6build.NewError(api.ErrCacheAccess, err)
 		return
 	}
 

--- a/pkg/cache/server/server.go
+++ b/pkg/cache/server/server.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"net/http"
 
+	"github.com/grafana/k6build"
 	"github.com/grafana/k6build/pkg/cache"
 	"github.com/grafana/k6build/pkg/cache/api"
 )
@@ -66,8 +67,8 @@ func (s *CacheServer) Get(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		resp.Error = ErrInvalidRequest.Error()
-		s.log.Error(resp.Error)
+		resp.Error = k6build.NewError(ErrInvalidRequest)
+		s.log.Error(resp.Error.Error())
 		_ = json.NewEncoder(w).Encode(resp) //nolint:errchkjson
 		return
 	}
@@ -81,7 +82,7 @@ func (s *CacheServer) Get(w http.ResponseWriter, r *http.Request) {
 			s.log.Error(err.Error())
 			w.WriteHeader(http.StatusInternalServerError)
 		}
-		resp.Error = err.Error()
+		resp.Error = k6build.NewError(err)
 		_ = json.NewEncoder(w).Encode(resp) //nolint:errchkjson
 
 		return
@@ -106,8 +107,8 @@ func (s *CacheServer) Store(w http.ResponseWriter, r *http.Request) {
 
 	// ensure errors are reported and logged
 	defer func() {
-		if resp.Error != "" {
-			s.log.Error(resp.Error)
+		if resp.Error != nil {
+			s.log.Error(resp.Error.Error())
 			_ = json.NewEncoder(w).Encode(resp) //nolint:errchkjson
 		}
 	}()
@@ -115,14 +116,14 @@ func (s *CacheServer) Store(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	if id == "" {
 		w.WriteHeader(http.StatusBadRequest)
-		resp.Error = ErrInvalidRequest.Error()
+		resp.Error = k6build.NewError(ErrInvalidRequest, fmt.Errorf("object id is required"))
 		return
 	}
 
 	object, err := s.cache.Store(context.Background(), id, r.Body) //nolint:contextcheck
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		resp.Error = err.Error()
+		resp.Error = k6build.NewError(err)
 		return
 	}
 

--- a/pkg/cache/server/server_test.go
+++ b/pkg/cache/server/server_test.go
@@ -101,7 +101,7 @@ func TestCacheServerGet(t *testing.T) {
 		title    string
 		id       string
 		status   int
-		epectErr string
+		epectErr error
 	}{
 		{
 			title:  "return object",
@@ -140,7 +140,7 @@ func TestCacheServerGet(t *testing.T) {
 			}
 
 			if tc.status != http.StatusOK {
-				if cacheResponse.Error == "" {
+				if cacheResponse.Error == nil {
 					t.Fatalf("expected error message not none")
 				}
 				return
@@ -208,7 +208,7 @@ func TestCacheServerStore(t *testing.T) {
 			}
 
 			if tc.status != http.StatusOK {
-				if cacheResponse.Error == "" {
+				if cacheResponse.Error == nil {
 					t.Fatalf("expected error message not none")
 				}
 				return

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -115,9 +115,9 @@ func TestRemote(t *testing.T) {
 		{
 			title: "build request failed",
 			handlers: []requestHandler{
-				withResponse(http.StatusOK, api.BuildResponse{Error: ErrBuildFailed.Error()}),
+				withResponse(http.StatusOK, api.BuildResponse{Error: k6build.NewError(api.ErrBuildFailed, nil)}),
 			},
-			expectErr: ErrBuildFailed,
+			expectErr: api.ErrBuildFailed,
 		},
 		{
 			title:    "auth header",
@@ -140,9 +140,9 @@ func TestRemote(t *testing.T) {
 		{
 			title: "failed auth",
 			handlers: []requestHandler{
-				withResponse(http.StatusUnauthorized, api.BuildResponse{Error: "Authorization Required"}),
+				withResponse(http.StatusUnauthorized, api.BuildResponse{Error: k6build.NewError(api.ErrRequestFailed, errors.New("unauthorized"))}),
 			},
-			expectErr: ErrRequestFailed,
+			expectErr: api.ErrRequestFailed,
 		},
 		{
 			title: "custom headers",

--- a/pkg/local/local.go
+++ b/pkg/local/local.go
@@ -208,13 +208,13 @@ func (b *localBuildSrv) Build( //nolint:funlen
 	}
 
 	if !errors.Is(err, cache.ErrObjectNotFound) {
-		return k6build.Artifact{}, fmt.Errorf("accessing artifact %w", err)
+		return k6build.Artifact{}, fmt.Errorf("accessing artifact: %w", err)
 	}
 
 	artifactBuffer := &bytes.Buffer{}
 	buildInfo, err := b.builder.Build(ctx, buildPlatform, k6Mod.Version, mods, []string{}, artifactBuffer)
 	if err != nil {
-		return k6build.Artifact{}, fmt.Errorf("building artifact  %w", err)
+		return k6build.Artifact{}, fmt.Errorf("building artifact: %w", err)
 	}
 
 	// if this is a prerelease, we must use the actual version built
@@ -225,7 +225,7 @@ func (b *localBuildSrv) Build( //nolint:funlen
 
 	artifactObject, err = b.cache.Store(ctx, id, artifactBuffer)
 	if err != nil {
-		return k6build.Artifact{}, fmt.Errorf("creating object  %w", err)
+		return k6build.Artifact{}, fmt.Errorf("creating object:  %w", err)
 	}
 
 	return k6build.Artifact{

--- a/pkg/local/local.go
+++ b/pkg/local/local.go
@@ -30,7 +30,11 @@ const (
 )
 
 var (
-	ErrInvalidConstrains = errors.New("invalid constrains") //nolint:revive
+	ErrAccessingArtifact    = errors.New("accessing artifact")           //nolint:revive
+	ErrBuildingArtifact     = errors.New("building artifact")            //nolint:revive
+	ErrInitializingBuilder  = errors.New("initializing builder")         //nolint:revive
+	ErrInvalidParameters    = errors.New("invalid build parameters")     //nolint:revive
+	ErrPrereleaseNotAllowed = errors.New("pre-releases are not allowed") //nolint:revive
 
 	constrainRe = regexp.MustCompile(opRe + verRe + preRe)
 )
@@ -67,7 +71,7 @@ type localBuildSrv struct {
 func NewBuildService(ctx context.Context, config BuildServiceConfig) (k6build.BuildService, error) {
 	catalog, err := k6catalog.NewCatalog(ctx, config.Catalog)
 	if err != nil {
-		return nil, fmt.Errorf("getting catalog %w", err)
+		return nil, k6build.NewError(ErrInitializingBuilder, err)
 	}
 
 	builderOpts := k6foundry.NativeBuilderOpts{
@@ -83,7 +87,7 @@ func NewBuildService(ctx context.Context, config BuildServiceConfig) (k6build.Bu
 
 	builder, err := k6foundry.NewNativeBuilder(ctx, builderOpts)
 	if err != nil {
-		return nil, fmt.Errorf("creating builder %w", err)
+		return nil, k6build.NewError(ErrInitializingBuilder, err)
 	}
 
 	var cache cache.Cache
@@ -95,12 +99,12 @@ func NewBuildService(ctx context.Context, config BuildServiceConfig) (k6build.Bu
 			},
 		)
 		if err != nil {
-			return nil, fmt.Errorf("creating cache client %w", err)
+			return nil, k6build.NewError(ErrInitializingBuilder, err)
 		}
 	} else {
 		cache, err = file.NewFileCache(config.CacheDir)
 		if err != nil {
-			return nil, fmt.Errorf("creating cache %w", err)
+			return nil, k6build.NewError(ErrInitializingBuilder, err)
 		}
 	}
 
@@ -116,17 +120,17 @@ func NewBuildService(ctx context.Context, config BuildServiceConfig) (k6build.Bu
 func DefaultLocalBuildService() (k6build.BuildService, error) {
 	catalog, err := k6catalog.DefaultCatalog()
 	if err != nil {
-		return nil, fmt.Errorf("creating catalog %w", err)
+		return nil, k6build.NewError(ErrInitializingBuilder, err)
 	}
 
 	builder, err := k6foundry.NewDefaultNativeBuilder()
 	if err != nil {
-		return nil, fmt.Errorf("creating builder %w", err)
+		return nil, k6build.NewError(ErrInitializingBuilder, err)
 	}
 
 	cache, err := file.NewTempFileCache()
 	if err != nil {
-		return nil, fmt.Errorf("creating temp cache %w", err)
+		return nil, k6build.NewError(ErrInitializingBuilder, err)
 	}
 
 	return &localBuildSrv{
@@ -144,7 +148,7 @@ func (b *localBuildSrv) Build( //nolint:funlen
 ) (k6build.Artifact, error) {
 	buildPlatform, err := k6foundry.ParsePlatform(platform)
 	if err != nil {
-		return k6build.Artifact{}, fmt.Errorf("invalid platform %w", err)
+		return k6build.Artifact{}, k6build.NewError(ErrInvalidParameters, err)
 	}
 
 	// sort dependencies to ensure idempotence of build
@@ -163,7 +167,7 @@ func (b *localBuildSrv) Build( //nolint:funlen
 	}
 	if prerelease != "" {
 		if !b.allowPrereleases {
-			return k6build.Artifact{}, fmt.Errorf("%w: pre-releases are not allowed", ErrInvalidConstrains)
+			return k6build.Artifact{}, k6build.NewError(ErrInvalidParameters, ErrPrereleaseNotAllowed)
 		}
 		k6Mod = k6catalog.Module{Path: k6Path, Version: prerelease}
 	} else {
@@ -208,13 +212,13 @@ func (b *localBuildSrv) Build( //nolint:funlen
 	}
 
 	if !errors.Is(err, cache.ErrObjectNotFound) {
-		return k6build.Artifact{}, fmt.Errorf("accessing artifact: %w", err)
+		return k6build.Artifact{}, k6build.NewError(ErrAccessingArtifact, err)
 	}
 
 	artifactBuffer := &bytes.Buffer{}
 	buildInfo, err := b.builder.Build(ctx, buildPlatform, k6Mod.Version, mods, []string{}, artifactBuffer)
 	if err != nil {
-		return k6build.Artifact{}, fmt.Errorf("building artifact: %w", err)
+		return k6build.Artifact{}, k6build.NewError(ErrAccessingArtifact, err)
 	}
 
 	// if this is a prerelease, we must use the actual version built
@@ -225,7 +229,7 @@ func (b *localBuildSrv) Build( //nolint:funlen
 
 	artifactObject, err = b.cache.Store(ctx, id, artifactBuffer)
 	if err != nil {
-		return k6build.Artifact{}, fmt.Errorf("creating object:  %w", err)
+		return k6build.Artifact{}, k6build.NewError(ErrAccessingArtifact, err)
 	}
 
 	return k6build.Artifact{
@@ -269,11 +273,11 @@ func isPrerelease(constrain string) (string, error) {
 	prerelease := matches[preIdx]
 
 	if op != "" && op != "=" {
-		return "", fmt.Errorf("%w only exact match is allowed for pre-release versions", ErrInvalidConstrains)
+		return "", k6build.NewError(ErrInvalidParameters, fmt.Errorf("only exact match is allowed for pre-release versions"))
 	}
 
 	if ver != "v0.0.0" {
-		return "", fmt.Errorf("%w prerelease version start with v0.0.0", ErrInvalidConstrains)
+		return "", k6build.NewError(ErrInvalidParameters, fmt.Errorf("prerelease version must start with v0.0.0"))
 	}
 	return prerelease, nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -73,7 +73,7 @@ func (a *APIServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		req.Dependencies,
 	)
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
+		w.WriteHeader(http.StatusOK)
 		resp.Error = k6build.NewError(api.ErrBuildFailed, err)
 		return
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,7 +4,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -51,8 +50,8 @@ func (a *APIServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// ensure errors are reported and logged
 	defer func() {
-		if resp.Error != "" {
-			a.log.Error(resp.Error)
+		if resp.Error != nil {
+			a.log.Error(resp.Error.Error())
 			_ = json.NewEncoder(w).Encode(resp) //nolint:errchkjson
 		}
 	}()
@@ -61,7 +60,7 @@ func (a *APIServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		resp.Error = fmt.Sprintf("invalid request: %s", err.Error())
+		resp.Error = k6build.NewError(api.ErrInvalidRequest, err)
 		return
 	}
 
@@ -75,7 +74,7 @@ func (a *APIServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
-		resp.Error = fmt.Sprintf("building artifact: %s", err.Error())
+		resp.Error = k6build.NewError(api.ErrBuildFailed, err)
 		return
 	}
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -4,9 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/grafana/k6build"
@@ -51,14 +51,6 @@ func buildErr(
 	return k6build.Artifact{}, k6build.ErrBuildFailed
 }
 
-func expectedError(expected string, actual string) bool {
-	if expected != "" {
-		return strings.Contains(actual, expected)
-	}
-
-	return actual == ""
-}
-
 func TestAPIServer(t *testing.T) {
 	t.Parallel()
 
@@ -67,7 +59,7 @@ func TestAPIServer(t *testing.T) {
 		build    buildFunction
 		req      []byte
 		status   int
-		err      string
+		err      error
 		artifact k6build.Artifact
 	}{
 		{
@@ -76,7 +68,7 @@ func TestAPIServer(t *testing.T) {
 			req:      []byte("{\"Platform\": \"linux/amd64\", \"K6Constrains\": \"v0.1.0\", \"Dependencies\": []}"),
 			status:   http.StatusOK,
 			artifact: k6build.Artifact{},
-			err:      "",
+			err:      nil,
 		},
 		{
 			title:    "build error",
@@ -84,7 +76,7 @@ func TestAPIServer(t *testing.T) {
 			req:      []byte("{\"Platform\": \"linux/amd64\", \"K6Constrains\": \"v0.1.0\", \"Dependencies\": []}"),
 			status:   http.StatusBadRequest,
 			artifact: k6build.Artifact{},
-			err:      k6build.ErrBuildFailed.Error(),
+			err:      api.ErrBuildFailed,
 		},
 		{
 			title:    "invalid request",
@@ -92,7 +84,7 @@ func TestAPIServer(t *testing.T) {
 			req:      []byte(""),
 			status:   http.StatusBadRequest,
 			artifact: k6build.Artifact{},
-			err:      "invalid request",
+			err:      api.ErrInvalidRequest,
 		},
 	}
 
@@ -127,7 +119,7 @@ func TestAPIServer(t *testing.T) {
 				t.Fatalf("decoding response %v", err)
 			}
 
-			if !expectedError(tc.err, buildResponse.Error) {
+			if tc.err != nil && !errors.Is(buildResponse.Error, tc.err) {
 				t.Fatalf("expected error: %q got %q", tc.err, buildResponse.Error)
 			}
 		})

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -74,7 +74,7 @@ func TestAPIServer(t *testing.T) {
 			title:    "build error",
 			build:    buildFunction(buildErr),
 			req:      []byte("{\"Platform\": \"linux/amd64\", \"K6Constrains\": \"v0.1.0\", \"Dependencies\": []}"),
-			status:   http.StatusBadRequest,
+			status:   http.StatusOK,
 			artifact: k6build.Artifact{},
 			err:      api.ErrBuildFailed,
 		},


### PR DESCRIPTION
Introduce a custom error type that facilitates creating errors that wrap another error as a Reason, and serializing them over the wire. 