### PR TITLE
Report dependency errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,12 @@ go 1.22.2
 
 require (
 	github.com/grafana/clireadme v0.1.0
-	github.com/grafana/k6catalog v0.2.3
+	github.com/grafana/k6catalog v0.2.4
 	github.com/grafana/k6foundry v0.3.0
 	github.com/spf13/cobra v1.8.1
 )
 
-require github.com/Masterminds/semver/v3 v3.3.0 // indirect
+require github.com/Masterminds/semver/v3 v3.3.1 // indirect
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,12 +1,12 @@
-github.com/Masterminds/semver/v3 v3.3.0 h1:B8LGeaivUe71a5qox1ICM/JLl0NqZSW5CHyL+hmvYS0=
-github.com/Masterminds/semver/v3 v3.3.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
+github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/grafana/clireadme v0.1.0 h1:KYEYSnYdSzmHf3bufaK6fQZ5j4dzvM/T+G6Ba+qNnAM=
 github.com/grafana/clireadme v0.1.0/go.mod h1:Wy4KIG2ZBGMYAYyF9l7qAy+yoJVasqk/txsRgoRI3gc=
-github.com/grafana/k6catalog v0.2.3 h1:Gol46qra9yjPYSrxLj6CDKcdY/DUEprM4Xd4TCNPkfA=
-github.com/grafana/k6catalog v0.2.3/go.mod h1:ozCf9+KBw63lNrRiZtp7CvzA7V0ATQuOQN2IoG2irw4=
+github.com/grafana/k6catalog v0.2.4 h1:P5wdlqz2APGZhe6qinwQCZXe+z/Rm65VQ7zP/djb4Ng=
+github.com/grafana/k6catalog v0.2.4/go.mod h1:nYzfIw6c3o1CEN1YlbUAkqtzIK2hoNWYF0lfYOk+RPg=
 github.com/grafana/k6foundry v0.3.0 h1:C+6dPbsOv7Uq4hEhBFNuYqmTdE9jQ0VqhXqBDtMkVTE=
 github.com/grafana/k6foundry v0.3.0/go.mod h1:/NtBSQQgXup5SVbfInl0Q8zKVx08xgvXIZ0xncqexEs=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/pkg/local/local.go
+++ b/pkg/local/local.go
@@ -173,7 +173,7 @@ func (b *localBuildSrv) Build( //nolint:funlen
 	} else {
 		k6Mod, err = b.catalog.Resolve(ctx, k6catalog.Dependency{Name: k6Dep, Constrains: k6Constrains})
 		if err != nil {
-			return k6build.Artifact{}, err
+			return k6build.Artifact{}, k6build.NewWrappedError(ErrInvalidParameters, err)
 		}
 	}
 	resolved[k6Dep] = k6Mod.Version
@@ -182,7 +182,7 @@ func (b *localBuildSrv) Build( //nolint:funlen
 	for _, d := range deps {
 		m, modErr := b.catalog.Resolve(ctx, k6catalog.Dependency{Name: d.Name, Constrains: d.Constraints})
 		if modErr != nil {
-			return k6build.Artifact{}, modErr
+			return k6build.Artifact{}, k6build.NewWrappedError(ErrInvalidParameters, modErr)
 		}
 		mods = append(mods, k6foundry.Module{Path: m.Path, Version: m.Version})
 		resolved[d.Name] = m.Version


### PR DESCRIPTION
Wrap all errors related to invalid or unsatisfiable in an `InvalidBuildParameters` error to facilitate differentiating them from other build errors. 