### PR TITLE
report store dir at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ curl http://external.url:9000/store/objectID/download
   -h, --help                  help for store
   -l, --log-level string      log level (default "INFO")
   -p, --port int              port server will listen (default 9000)
-  -c, --store-dir string      object store directory (default "/tmp/store/objectstore")
+  -c, --store-dir string      object store directory (default "/tmp/k6build/store")
 ```
 
 ## SEE ALSO

--- a/cmd/store/store.go
+++ b/cmd/store/store.go
@@ -100,7 +100,7 @@ func New() *cobra.Command {
 			srv.Handle("/store/", http.StripPrefix("/store", storeSrv))
 
 			listerAddr := fmt.Sprintf("0.0.0.0:%d", port)
-			log.Info("starting server", "address", listerAddr)
+			log.Info("starting server", "address", listerAddr, "object store", storeDir)
 			err = http.ListenAndServe(listerAddr, srv) //nolint:gosec
 			if err != nil {
 				log.Info("server ended", "error", err.Error())
@@ -111,7 +111,7 @@ func New() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&storeDir, "store-dir", "c", "/tmp/store/objectstore", "object store directory")
+	cmd.Flags().StringVarP(&storeDir, "store-dir", "c", "/tmp/k6build/store", "object store directory")
 	cmd.Flags().IntVarP(&port, "port", "p", 9000, "port server will listen")
 	cmd.Flags().StringVarP(&storeSrvURL,
 		"download-url", "d", "", "base url used for downloading objects."+


### PR DESCRIPTION
This facilitates cleanup of the object store for testing/debugging.

This PR also changes the default object store directory to make it easier to infer its purpose.