### PR TITLE
Cgo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,9 +229,8 @@ For example
 	  }
 	}
 
-Note: The build server does not support CGO_ENABLE when building binaries
-      due to this issue: https://github.com/grafana/k6build/issues/37
-      use --enable-cgo=true to enable CGO support
+Note: The build server disables CGO by default but enables it when a dependency requires it.
+      use --enable-cgo=true to enable CGO support by default.
 
 
 ```

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -54,9 +54,8 @@ For example
 	  }
 	}
 
-Note: The build server does not support CGO_ENABLE when building binaries
-      due to this issue: https://github.com/grafana/k6build/issues/37
-      use --enable-cgo=true to enable CGO support
+Note: The build server disables CGO by default but enables it when a dependency requires it.
+      use --enable-cgo=true to enable CGO support by default.
 `
 
 	example = `

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -59,15 +59,14 @@ type Config struct {
 
 // Builder implements the BuildService interface
 type Builder struct {
-	allowBuildSemvers bool
-	catalog           catalog.Catalog
-	builder           k6foundry.Builder
-	store             store.ObjectStore
-	mutexes           sync.Map
+	opts    Opts
+	catalog catalog.Catalog
+	store   store.ObjectStore
+	mutexes sync.Map
 }
 
 // New returns a new instance of Builder given a BuilderConfig
-func New(ctx context.Context, config Config) (*Builder, error) {
+func New(_ context.Context, config Config) (*Builder, error) {
 	if config.Catalog == nil {
 		return nil, k6build.NewWrappedError(ErrInitializingBuilder, errors.New("catalog cannot be nil"))
 	}
@@ -76,27 +75,10 @@ func New(ctx context.Context, config Config) (*Builder, error) {
 		return nil, k6build.NewWrappedError(ErrInitializingBuilder, errors.New("store cannot be nil"))
 	}
 
-	builderOpts := k6foundry.NativeBuilderOpts{
-		GoOpts: k6foundry.GoOpts{
-			Env:       config.Opts.Env,
-			CopyGoEnv: config.Opts.CopyGoEnv,
-		},
-	}
-	if config.Opts.Verbose {
-		builderOpts.Stdout = os.Stdout
-		builderOpts.Stderr = os.Stderr
-	}
-
-	builder, err := k6foundry.NewNativeBuilder(ctx, builderOpts)
-	if err != nil {
-		return nil, k6build.NewWrappedError(ErrInitializingBuilder, err)
-	}
-
 	return &Builder{
-		allowBuildSemvers: config.Opts.AllowBuildSemvers,
-		catalog:           config.Catalog,
-		builder:           builder,
-		store:             config.Store,
+		catalog: config.Catalog,
+		opts:    config.Opts,
+		store:   config.Store,
 	}, nil
 }
 
@@ -127,7 +109,7 @@ func (b *Builder) Build( //nolint:funlen
 		return k6build.Artifact{}, err
 	}
 	if buildMetadata != "" {
-		if !b.allowBuildSemvers {
+		if !b.opts.AllowBuildSemvers {
 			return k6build.Artifact{}, k6build.NewWrappedError(ErrInvalidParameters, ErrBuildSemverNotAllowed)
 		}
 		k6Mod = catalog.Module{Path: k6Path, Version: buildMetadata}
@@ -176,8 +158,24 @@ func (b *Builder) Build( //nolint:funlen
 		return k6build.Artifact{}, k6build.NewWrappedError(ErrAccessingArtifact, err)
 	}
 
+	builderOpts := k6foundry.NativeBuilderOpts{
+		GoOpts: k6foundry.GoOpts{
+			Env:       b.opts.Env,
+			CopyGoEnv: b.opts.CopyGoEnv,
+		},
+	}
+	if b.opts.Verbose {
+		builderOpts.Stdout = os.Stdout
+		builderOpts.Stderr = os.Stderr
+	}
+
+	builder, err := k6foundry.NewNativeBuilder(ctx, builderOpts)
+	if err != nil {
+		return k6build.Artifact{}, k6build.NewWrappedError(ErrInitializingBuilder, err)
+	}
+
 	artifactBuffer := &bytes.Buffer{}
-	buildInfo, err := b.builder.Build(ctx, buildPlatform, k6Mod.Version, mods, []string{}, artifactBuffer)
+	buildInfo, err := builder.Build(ctx, buildPlatform, k6Mod.Version, mods, []string{}, artifactBuffer)
 	if err != nil {
 		return k6build.Artifact{}, k6build.NewWrappedError(ErrAccessingArtifact, err)
 	}
@@ -205,7 +203,7 @@ func (b *Builder) Build( //nolint:funlen
 // lockArtifact obtains a mutex used to prevent concurrent builds of the same artifact and
 // returns a function that will unlock the mutex associated to the given id in the object store.
 // The lock is also removed from the map. Subsequent calls will get another lock on the same
-// id but this is safe as the object should already be in the object strore and no further
+// id but this is safe as the object should already be in the object store and no further
 // builds are needed.
 func (b *Builder) lockArtifact(id string) func() {
 	value, _ := b.mutexes.LoadOrStore(id, &sync.Mutex{})

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -11,10 +11,10 @@ import (
 	"testing"
 )
 
-const (
-	testCatalog    = `{ "dep": {"Module": "github.com/dep", "Versions": ["v0.1.0", "v0.2.0"]}}`
-	invalidCatalog = `{ "dep": {}}`
-)
+const testCatalog = `{
+"dep": {"Module": "github.com/dep", "Versions": ["v0.1.0", "v0.2.0"]},
+"dep2": {"Module": "github.com/dep2", "Versions": ["v0.1.0"], "Cgo": true}
+}`
 
 func TestResolve(t *testing.T) {
 	t.Parallel()
@@ -28,17 +28,22 @@ func TestResolve(t *testing.T) {
 		{
 			title:  "resolve exact version",
 			dep:    Dependency{Name: "dep", Constrains: "v0.1.0"},
-			expect: Module{Path: "github.com/dep", Version: "v0.1.0"},
+			expect: Module{Path: "github.com/dep", Version: "v0.1.0", Cgo: false},
 		},
 		{
 			title:  "resolve > constrain",
 			dep:    Dependency{Name: "dep", Constrains: ">v0.1.0"},
-			expect: Module{Path: "github.com/dep", Version: "v0.2.0"},
+			expect: Module{Path: "github.com/dep", Version: "v0.2.0", Cgo: false},
 		},
 		{
 			title:  "resolve latest version",
 			dep:    Dependency{Name: "dep", Constrains: "*"},
-			expect: Module{Path: "github.com/dep", Version: "v0.2.0"},
+			expect: Module{Path: "github.com/dep", Version: "v0.2.0", Cgo: false},
+		},
+		{
+			title:  "resolve cgo dependency",
+			dep:    Dependency{Name: "dep2", Constrains: "=v0.1.0"},
+			expect: Module{Path: "github.com/dep2", Version: "v0.1.0", Cgo: true},
 		},
 		{
 			title:     "unsatisfied > constrain",

--- a/pkg/catalog/schema.json
+++ b/pkg/catalog/schema.json
@@ -17,7 +17,12 @@
                                         "type": "string",
                                         "pattern": "^v(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)$"
                                 }
+                        },
+                        "cgo": {
+                                "type": "boolean",
+                                "description": "whether the dependency requires cgo"
                         }
+
                 },
                 "required": [
                         "module",


### PR DESCRIPTION
This PR introduces changes in how binaries are built, the most important being that now a native builder is created for each build request so that we can set the `CGO_ENABLED` variable accordingly if a dependency requires it.


Due to limitations in the current testing setup it is not easy to automate the tests for this feature. Therefore it was tested using the following manual procedure:

```
# run local build for an extension that requires cgo
$ go run ./cmd/k6build/main.go local  -k v0.56 -p "linux/amd64" -d "k6/x/sql" -d "k6/x/sql/driver/sqlite3" -o k6
platform: linux/amd64

k6:"v0.56.0"
k6/x/sql:"v1.0.1"
k6/x/sql/driver/sqlite3:"v0.1.0"
checksum: 0eea072bedd3dc0aa9be1c5ccd768d172c9551d304ffbbcfa2a214c6ece7a475

# check k6 version
$  ./k6 version
k6 v0.56.0 (go1.22.4, linux/amd64)
Extensions:
  github.com/grafana/xk6-sql v1.0.1, k6/x/sql [js]
  github.com/grafana/xk6-sql v1.0.1, k6/x/sql/driver/sqlite3 [js]

# check the binary was build with dynamic libraries
$ ldd k6
        linux-vdso.so.1 (0x00007fff6d1fc000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x000076ec43e00000)
        /lib64/ld-linux-x86-64.so.2 (0x000076ec440d4000)
```
Fixes https://github.com/grafana/k6build/issues/88