### PR TITLE
remove path from store endpoint config

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ k6build server --s3-endpoint http://localhost:4566 --store-bucket k6build
       --s3-endpoint string    s3 endpoint
       --s3-region string      aws region
       --store-bucket string   s3 bucket for storing binaries
-      --store-url string      store server url (default "http://localhost:9000/store")
+      --store-url string      store server url (default "http://localhost:9000")
   -v, --verbose               print build process output
 ```
 
@@ -339,7 +339,7 @@ curl http://external.url:9000/store/objectID/download
 
 ```
   -d, --download-url string   base url used for downloading objects.
-                              If not specified http://localhost:<port>/store is used
+                              If not specified http://localhost:<port> is used
   -h, --help                  help for store
   -l, --log-level string      log level (default "INFO")
   -p, --port int              port server will listen (default 9000)

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -203,7 +203,7 @@ func New() *cobra.Command { //nolint:funlen
 		"dependencies catalog. Can be path to a local file or an URL."+
 			"\n",
 	)
-	cmd.Flags().StringVar(&storeURL, "store-url", "http://localhost:9000/store", "store server url")
+	cmd.Flags().StringVar(&storeURL, "store-url", "http://localhost:9000", "store server url")
 	cmd.Flags().StringVar(&s3Bucket, "store-bucket", "", "s3 bucket for storing binaries")
 	cmd.Flags().StringVar(&s3Endpoint, "s3-endpoint", "", "s3 endpoint")
 	cmd.Flags().StringVar(&s3Region, "s3-region", "", "aws region")

--- a/cmd/store/store.go
+++ b/cmd/store/store.go
@@ -96,7 +96,7 @@ func New() *cobra.Command {
 			}
 
 			srv := http.NewServeMux()
-			srv.Handle("/store/", http.StripPrefix("/store", storeSrv))
+			srv.Handle("/store/", storeSrv)
 
 			listerAddr := fmt.Sprintf("0.0.0.0:%d", port)
 			log.Info("starting server", "address", listerAddr, "object store", storeDir)
@@ -114,7 +114,7 @@ func New() *cobra.Command {
 	cmd.Flags().IntVarP(&port, "port", "p", 9000, "port server will listen")
 	cmd.Flags().StringVarP(&storeSrvURL,
 		"download-url", "d", "", "base url used for downloading objects."+
-			"\nIf not specified http://localhost:<port>/store is used",
+			"\nIf not specified http://localhost:<port> is used",
 	)
 	cmd.Flags().StringVarP(&logLevel, "log-level", "l", "INFO", "log level")
 

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -19,6 +19,7 @@ import (
 	strclient "github.com/grafana/k6build/pkg/store/client"
 	filestore "github.com/grafana/k6build/pkg/store/file"
 	storesrv "github.com/grafana/k6build/pkg/store/server"
+	"github.com/grafana/k6build/pkg/util"
 )
 
 func Test_BuildServer(t *testing.T) {
@@ -94,7 +95,12 @@ func Test_BuildServer(t *testing.T) {
 				t.Fatalf("client setup %v", err)
 			}
 
-			_, err = client.Build(context.TODO(), tc.platform, tc.k6Constrain, tc.deps)
+			artifact, err := client.Build(context.TODO(), tc.platform, tc.k6Constrain, tc.deps)
+			if err != nil {
+				t.Fatalf("building artifact  %v", err)
+			}
+
+			err = util.Download(context.TODO(), artifact.URL, filepath.Join(t.TempDir(), "k6"))
 			if err != nil {
 				t.Fatalf("building artifact  %v", err)
 			}

--- a/pkg/store/client/client.go
+++ b/pkg/store/client/client.go
@@ -49,7 +49,7 @@ func NewStoreClient(config StoreClientConfig) (*StoreClient, error) {
 
 // Get retrieves an objects if exists in the store or an error otherwise
 func (c *StoreClient) Get(ctx context.Context, id string) (store.Object, error) {
-	reqURL := *c.server.JoinPath(id)
+	reqURL := *c.server.JoinPath("store", id)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL.String(), nil)
 	if err != nil {
 		return store.Object{}, k6build.NewWrappedError(api.ErrInvalidRequest, err)
@@ -85,7 +85,7 @@ func (c *StoreClient) Get(ctx context.Context, id string) (store.Object, error) 
 
 // Put stores the object and returns the metadata
 func (c *StoreClient) Put(ctx context.Context, id string, content io.Reader) (store.Object, error) {
-	reqURL := *c.server.JoinPath(id)
+	reqURL := *c.server.JoinPath("store", id)
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodPost,

--- a/pkg/store/server/server.go
+++ b/pkg/store/server/server.go
@@ -162,7 +162,18 @@ func getDownloadURL(baseURL *url.URL, r *http.Request) string {
 		return baseURL.JoinPath("store", r.PathValue("id"), "download").String()
 	}
 
-	return r.URL.JoinPath("download").String()
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+
+	url := url.URL{
+		Scheme: scheme,
+		Host:   r.Host,
+		Path:   r.URL.JoinPath("download").String(),
+	}
+
+	return url.String()
 }
 
 // Download returns an object's content given its id

--- a/pkg/store/server/server.go
+++ b/pkg/store/server/server.go
@@ -70,9 +70,9 @@ func NewStoreServer(config StoreServerConfig) (http.Handler, error) {
 
 	handler := http.NewServeMux()
 	// FIXME: this should be PUT (used POST as http client doesn't have PUT method)
-	handler.HandleFunc("POST /{id}", storeSrv.Store)
-	handler.HandleFunc("GET /{id}", storeSrv.Get)
-	handler.HandleFunc("GET /{id}/download", storeSrv.Download)
+	handler.HandleFunc("POST /store/{id}", storeSrv.Store)
+	handler.HandleFunc("GET /store/{id}", storeSrv.Get)
+	handler.HandleFunc("GET /store/{id}/download", storeSrv.Download)
 
 	return handler, nil
 }
@@ -159,7 +159,7 @@ func (s *StoreServer) Store(w http.ResponseWriter, r *http.Request) {
 
 func getDownloadURL(baseURL *url.URL, r *http.Request) string {
 	if baseURL != nil {
-		return baseURL.JoinPath(r.PathValue("id"), "download").String()
+		return baseURL.JoinPath("store", r.PathValue("id"), "download").String()
 	}
 
 	return r.URL.JoinPath("download").String()

--- a/pkg/store/server/server_test.go
+++ b/pkg/store/server/server_test.go
@@ -64,7 +64,7 @@ func TestStoreServerGet(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			t.Parallel()
 
-			url := fmt.Sprintf("%s/%s", srv.URL, tc.id)
+			url := fmt.Sprintf("%s/store/%s", srv.URL, tc.id)
 			resp, err := http.Get(url)
 			if err != nil {
 				t.Fatalf("accessing server %v", err)
@@ -134,7 +134,7 @@ func TestStoreServerPut(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			t.Parallel()
 
-			url := fmt.Sprintf("%s/%s", srv.URL, tc.id)
+			url := fmt.Sprintf("%s/store/%s", srv.URL, tc.id)
 			resp, err := http.Post(
 				url,
 				"application/octet-stream",
@@ -224,7 +224,7 @@ func TestStoreServerDownload(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			t.Parallel()
 
-			url := fmt.Sprintf("%s/%s/download", srv.URL, tc.id)
+			url := fmt.Sprintf("%s/store/%s/download", srv.URL, tc.id)
 			resp, err := http.Get(url)
 			if err != nil {
 				t.Fatalf("accessing server %v", err)


### PR DESCRIPTION
For consistency with the build service and to facilitate the configuration of proxies and ingresses that point to the store server, remote the path from the store base URL. 