### PR TITLE
retract v0.5.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -95,4 +95,7 @@ require (
 	golang.org/x/mod v0.23.0 // indirect
 )
 
-retract v0.0.0 // premature publishing
+retract (
+	v0.5.7 // corrupted cache
+	v0.0.0 // premature publishing
+)


### PR DESCRIPTION
This version has a cache corruption that makes `go mod tidy` to fail in projects using it as a dependency:

```
go mod tidy
verifying github.com/grafana/k6build@v0.5.7: checksum mismatch
        downloaded: h1:T/kAwBjBncWy+3UY3H/MDFwRFLea3Nqlygi98nEnPWI=
        go.sum:     h1:2GCPtZPuKAtqdjI0gFzQj4k4TTJprjEBLq2RWcxNQ5k=
```