### PR TITLE
Add version command - fixes #66

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.24"
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -84,7 +84,6 @@ linters:
     - errname
     - errorlint
     - exhaustive
-    - exportloopref
     - forbidigo
     - forcetypeassert
     - funlen

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v1.62.2
+# v1.64.8
 # Please don't remove the first line. It uses in CI to determine the golangci version
 run:
   timeout: 5m

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2,6 +2,11 @@
 package cmd
 
 import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"strings"
+
 	"github.com/spf13/cobra"
 
 	"github.com/grafana/k6build/cmd/local"
@@ -19,12 +24,104 @@ func New() *cobra.Command {
 		SilenceErrors:     true,
 		DisableAutoGenTag: true,
 		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
+		Version:           fullVersion(),
 	}
 
 	root.AddCommand(store.New())
 	root.AddCommand(remote.New())
 	root.AddCommand(local.New())
 	root.AddCommand(server.New())
+	root.AddCommand(newVersionCommand())
 
 	return root
+}
+
+func newVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:           "version",
+		Short:         "k6build version",
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			root := cmd.Root()
+			root.SetArgs([]string{"--version"})
+			_ = root.Execute()
+			return nil
+		},
+	}
+}
+
+const (
+	commitKey      = "commit"
+	commitDirtyKey = "commit_dirty"
+)
+
+// fullVersion returns the maximally full version and build information for
+// the currently running k6build executable.
+func fullVersion() string {
+	details := versionDetails()
+
+	goVersionArch := fmt.Sprintf("%s, %s/%s", details["go_version"], details["go_os"], details["go_arch"])
+
+	k6buildversion := fmt.Sprintf("%s", details["version"])
+	// for the fallback case when the version is not in the expected format
+	// cobra adds a "v" prefix to the version
+	k6buildversion = strings.TrimLeft(k6buildversion, "v")
+
+	commit, ok := details[commitKey].(string)
+	if !ok || commit == "" {
+		return fmt.Sprintf("%s (%s)", k6buildversion, goVersionArch)
+	}
+
+	isDirty, ok := details[commitDirtyKey].(bool)
+	if ok && isDirty {
+		commit += "-dirty"
+	}
+
+	return fmt.Sprintf("%s (commit/%s, %s)", k6buildversion, commit, goVersionArch)
+}
+
+// versionDetails returns the structured details about version
+func versionDetails() map[string]any {
+	v := "unreleased"
+
+	details := map[string]any{
+		"version":    v,
+		"go_version": runtime.Version(),
+		"go_os":      runtime.GOOS,
+		"go_arch":    runtime.GOARCH,
+	}
+
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return details
+	}
+	details["version"] = buildInfo.Main.Version
+
+	var (
+		commit string
+		dirty  bool
+	)
+	for _, s := range buildInfo.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			commitLen := min(len(s.Value), 10)
+			commit = s.Value[:commitLen]
+		case "vcs.modified":
+			if s.Value == "true" {
+				dirty = true
+			}
+		default:
+		}
+	}
+
+	if commit == "" {
+		return details
+	}
+
+	details[commitKey] = commit
+	if dirty {
+		details[commitDirtyKey] = true
+	}
+
+	return details
 }

--- a/cmd/store/store.go
+++ b/cmd/store/store.go
@@ -48,7 +48,7 @@ curl http://external.url:9000/store/objectID/download
 )
 
 // New creates new cobra command for store command.
-func New() *cobra.Command { //nolint:funlen
+func New() *cobra.Command {
 	var (
 		storeDir        string
 		storeSrvURL     string

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/grafana/k6build
 
-go 1.23.0
-
-toolchain go1.23.7
+go 1.24.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -124,7 +124,7 @@ func New(_ context.Context, config Config) (*Builder, error) {
 }
 
 // Build builds a custom k6 binary with dependencies
-func (b *Builder) Build( //nolint:funlen
+func (b *Builder) Build(
 	ctx context.Context,
 	platform string,
 	k6Constrains string,


### PR DESCRIPTION
The version will be

With  `go run` :

```
k6build version (devel) (go1.24.3, linux/amd64)   
```

With `go build it is` 

```
k6build version 0.5.12-0.20250617093855-32e3d2473c4d+dirty (commit/32e3d2473c-dirty, go1.24.3, linux/amd64)
```

or 

```
k6build version 0.5.12-0.20250617093855-32e3d2473c4d (commit/32e3d2473c-dirty, go1.24.3, linux/amd64)
```

if the index doesn't have anything in it, `go install` will be something similar but it should be even more concise.


I do expect more changes will be needed to make it look okay with a fully released version.