### PR TITLE
Improve error reporting

### DIFF
--- a/build.go
+++ b/build.go
@@ -8,7 +8,12 @@ import (
 	"fmt"
 )
 
-var ErrBuildFailed = errors.New("build failed") //nolint:revive
+var (
+	ErrAccessingArtifact     = errors.New("accessing artifact") //nolint:revive
+	ErrBuildFailed           = errors.New("build failed")
+	ErrInvalidParameters     = errors.New("invalid build parameters")
+	ErrResolvingDependencies = errors.New("resolving dependencies")
+)
 
 // Dependency defines a dependency and its semantic version constrains
 type Dependency struct {

--- a/build.go
+++ b/build.go
@@ -11,6 +11,7 @@ import (
 var (
 	ErrAccessingArtifact     = errors.New("accessing artifact") //nolint:revive
 	ErrBuildFailed           = errors.New("build failed")
+	ErrCatalog               = errors.New("accessing catalog")
 	ErrInvalidParameters     = errors.New("invalid build parameters")
 	ErrResolvingDependencies = errors.New("resolving dependencies")
 )

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -398,7 +398,7 @@ func (b *Builder) buildArtifact(
 	_, err = builder.Build(ctx, buildPlatform, k6Version, mods, nil, []string{}, artifactBuffer)
 	if err != nil {
 		b.metrics.buildsFailedCounter.Inc()
-		return k6build.NewWrappedError(k6build.ErrAccessingArtifact, err)
+		return k6build.NewWrappedError(k6build.ErrBuildFailed, err)
 	}
 
 	// TODO: complete artifact info

--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -181,7 +181,7 @@ func (b *Builder) Build(
 
 	err = b.buildArtifact(ctx, platform, resolved, artifactBuffer)
 	if err != nil {
-		return k6build.Artifact{}, k6build.NewWrappedError(k6build.ErrBuildFailed, err)
+		return k6build.Artifact{}, err
 	}
 	buildTimer.ObserveDuration()
 

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -109,7 +109,7 @@ func TestBuild(t *testing.T) {
 			title:     "build unsatisfied constrain (>v0.2.0)",
 			k6:        ">v0.2.0",
 			deps:      []k6build.Dependency{},
-			expectErr: ErrInvalidParameters,
+			expectErr: k6build.ErrInvalidParameters,
 		},
 	}
 
@@ -176,7 +176,7 @@ func TestResolve(t *testing.T) {
 			title:     "unsatisfied k6 constrain (>v0.2.0)",
 			k6:        ">v0.2.0",
 			deps:      []k6build.Dependency{},
-			expectErr: ErrResolvingDependencies,
+			expectErr: k6build.ErrResolvingDependencies,
 		},
 		{
 			title:     "resolve multiple dependencies constraint",
@@ -192,7 +192,7 @@ func TestResolve(t *testing.T) {
 			title:     "build k6 v0.1.0 unsatisfied dependency constrain",
 			k6:        "v0.1.0",
 			deps:      []k6build.Dependency{{Name: "k6/x/ext", Constraints: ">v0.2.0"}},
-			expectErr: ErrResolvingDependencies,
+			expectErr: k6build.ErrResolvingDependencies,
 		},
 	}
 
@@ -536,7 +536,7 @@ func TestMetrics(t *testing.T) {
 					[]k6build.Dependency{},
 				)
 				// ignore unsatisfied builds as they are expected
-				if err != nil && !errors.Is(err, ErrInvalidParameters) {
+				if err != nil && !errors.Is(err, k6build.ErrInvalidParameters) {
 					t.Fatalf("unexpected %v", err)
 				}
 			}

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -176,7 +176,7 @@ func TestResolve(t *testing.T) {
 			title:     "unsatisfied k6 constrain (>v0.2.0)",
 			k6:        ">v0.2.0",
 			deps:      []k6build.Dependency{},
-			expectErr: k6build.ErrResolvingDependencies,
+			expectErr: k6build.ErrInvalidParameters,
 		},
 		{
 			title:     "resolve multiple dependencies constraint",
@@ -192,7 +192,7 @@ func TestResolve(t *testing.T) {
 			title:     "build k6 v0.1.0 unsatisfied dependency constrain",
 			k6:        "v0.1.0",
 			deps:      []k6build.Dependency{{Name: "k6/x/ext", Constraints: ">v0.2.0"}},
-			expectErr: k6build.ErrResolvingDependencies,
+			expectErr: k6build.ErrInvalidParameters,
 		},
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,6 +4,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -56,10 +57,15 @@ func (a *APIServer) Build(w http.ResponseWriter, r *http.Request) {
 
 	// ensure errors are reported and logged
 	defer func() {
-		if resp.Error != nil {
+		switch {
+		case resp.Error == nil:
+			return
+		case errors.Is(resp.Error, k6build.ErrInvalidParameters):
+			a.log.Info(resp.Error.Error())
+		default:
 			a.log.Error(resp.Error.Error())
-			_ = json.NewEncoder(w).Encode(resp) //nolint:errchkjson
 		}
+		_ = json.NewEncoder(w).Encode(resp) //nolint:errchkjson
 	}()
 
 	req := api.BuildRequest{}
@@ -102,10 +108,15 @@ func (a *APIServer) Resolve(w http.ResponseWriter, r *http.Request) {
 
 	// ensure errors are reported and logged
 	defer func() {
-		if resp.Error != nil {
+		switch {
+		case resp.Error == nil:
+			return
+		case errors.Is(resp.Error, k6build.ErrInvalidParameters):
+			a.log.Info(resp.Error.Error())
+		default:
 			a.log.Error(resp.Error.Error())
-			_ = json.NewEncoder(w).Encode(resp) //nolint:errchkjson
 		}
+		_ = json.NewEncoder(w).Encode(resp) //nolint:errchkjson
 	}()
 
 	req := api.ResolveRequest{}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -55,19 +55,6 @@ func (a *APIServer) Build(w http.ResponseWriter, r *http.Request) {
 
 	resp := api.BuildResponse{}
 
-	// ensure errors are reported and logged
-	defer func() {
-		switch {
-		case resp.Error == nil:
-			return
-		case errors.Is(resp.Error, k6build.ErrInvalidParameters):
-			a.log.Info(resp.Error.Error())
-		default:
-			a.log.Error(resp.Error.Error())
-		}
-		_ = json.NewEncoder(w).Encode(resp) //nolint:errchkjson
-	}()
-
 	req := api.BuildRequest{}
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
@@ -86,17 +73,22 @@ func (a *APIServer) Build(w http.ResponseWriter, r *http.Request) {
 		req.K6Constrains,
 		req.Dependencies,
 	)
-	if err != nil {
+
+	switch {
+	case err == nil:
 		w.WriteHeader(http.StatusOK)
+		resp.Artifact = artifact
+		a.log.Debug("returning", "response", resp.String())
+	case errors.Is(err, k6build.ErrInvalidParameters):
+		w.WriteHeader(http.StatusOK)
+		resp.Error = k6build.NewWrappedError(api.ErrCannotSatisfy, err)
+		a.log.Info(resp.Error.Error())
+	default:
 		resp.Error = k6build.NewWrappedError(api.ErrBuildFailed, err)
-		return
+		w.WriteHeader(http.StatusInternalServerError)
+		a.log.Error(resp.Error.Error())
 	}
 
-	resp.Artifact = artifact
-
-	a.log.Debug("returning", "response", resp.String())
-
-	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(resp) //nolint:errchkjson
 }
 
@@ -106,24 +98,10 @@ func (a *APIServer) Resolve(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Add("Content-Type", "application/json")
 
-	// ensure errors are reported and logged
-	defer func() {
-		switch {
-		case resp.Error == nil:
-			return
-		case errors.Is(resp.Error, k6build.ErrInvalidParameters):
-			a.log.Info(resp.Error.Error())
-		default:
-			a.log.Error(resp.Error.Error())
-		}
-		_ = json.NewEncoder(w).Encode(resp) //nolint:errchkjson
-	}()
-
 	req := api.ResolveRequest{}
 	decoder := json.NewDecoder(r.Body)
 	decoder.DisallowUnknownFields()
 	err := decoder.Decode(&req)
-	// err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		resp.Error = k6build.NewWrappedError(api.ErrInvalidRequest, err)
@@ -137,15 +115,21 @@ func (a *APIServer) Resolve(w http.ResponseWriter, r *http.Request) {
 		req.K6Constrains,
 		req.Dependencies,
 	)
-	if err != nil {
+
+	switch {
+	case err == nil:
+		resp.Dependencies = deps
 		w.WriteHeader(http.StatusOK)
+		a.log.Debug("returning", "response", resp.String())
+	case errors.Is(err, k6build.ErrInvalidParameters):
+		w.WriteHeader(http.StatusOK)
+		resp.Error = k6build.NewWrappedError(api.ErrCannotSatisfy, err)
+		a.log.Info(resp.Error.Error())
+	default:
 		resp.Error = k6build.NewWrappedError(api.ErrResolveFailed, err)
-		return
+		w.WriteHeader(http.StatusInternalServerError)
+		a.log.Error(resp.Error.Error())
 	}
 
-	a.log.Debug("returning", "response", resp.String())
-
-	resp.Dependencies = deps
-	w.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(w).Encode(resp) //nolint:errchkjson
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -103,7 +103,7 @@ func TestAPI(t *testing.T) {
 			path:         "build",
 			req:          &api.BuildRequest{Platform: "linux/amd64", K6Constrains: "v0.1.0"},
 			resp:         &api.BuildResponse{},
-			expectStatus: http.StatusOK,
+			expectStatus: http.StatusInternalServerError,
 			expectErr:    api.ErrBuildFailed,
 		},
 		{
@@ -145,7 +145,7 @@ func TestAPI(t *testing.T) {
 		{
 			title: "resolve error",
 			builder: mockBuilder{
-				err: api.ErrCannotSatisfy,
+				err: k6build.ErrInvalidParameters,
 			},
 			path:         "resolve",
 			req:          &api.ResolveRequest{K6Constrains: "v0.1.0"},


### PR DESCRIPTION
This PR implements a more granular and more consistent error reporting from the build service
1. Differentiates build errors from unsatisfiable requests (e.g. unsupported extensions or versions)
2. Reports unsatisfied requests in INFO log messages
3. Properly reports build errors with status code 500

> NOTE: this PR introduces potentially breaking changes in the API as error description for some cases may change

Fixes: https://github.com/grafana/k6build/issues/219