### PR TITLE
Pass request context to build service methods

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -73,7 +73,7 @@ func (a *APIServer) Build(w http.ResponseWriter, r *http.Request) {
 
 	a.log.Debug("processing", "request", req.String())
 
-	artifact, err := a.srv.Build( //nolint:contextcheck
+	artifact, err := a.srv.Build(
 		r.Context(),
 		req.Platform,
 		req.K6Constrains,
@@ -120,7 +120,7 @@ func (a *APIServer) Resolve(w http.ResponseWriter, r *http.Request) {
 
 	a.log.Debug("processing", "request", req.String())
 
-	deps, err := a.srv.Resolve( //nolint:contextcheck
+	deps, err := a.srv.Resolve(
 		r.Context(),
 		req.K6Constrains,
 		req.Dependencies,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2,7 +2,6 @@
 package server
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -75,7 +74,7 @@ func (a *APIServer) Build(w http.ResponseWriter, r *http.Request) {
 	a.log.Debug("processing", "request", req.String())
 
 	artifact, err := a.srv.Build( //nolint:contextcheck
-		context.Background(),
+		r.Context(),
 		req.Platform,
 		req.K6Constrains,
 		req.Dependencies,
@@ -122,7 +121,7 @@ func (a *APIServer) Resolve(w http.ResponseWriter, r *http.Request) {
 	a.log.Debug("processing", "request", req.String())
 
 	deps, err := a.srv.Resolve( //nolint:contextcheck
-		context.Background(),
+		r.Context(),
 		req.K6Constrains,
 		req.Dependencies,
 	)


### PR DESCRIPTION
If a client disconnects, the context cancellation should propagate down the call stack, hence I propose passing the request context instead of a background one.