### PR TITLE
chore: add renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>grafana/grafana-renovate-config//presets/k6/k6-engine-base.json"
+  ]
+}


### PR DESCRIPTION
Adds `renovate.json` extending the [k6-engine-base preset](https://github.com/grafana/grafana-renovate-config/blob/main/presets/k6/k6-engine-base.json).