### PR TITLE
Correlate log lines with traces via trace_id/span_id

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -402,11 +402,13 @@ func getLogger(logLevel string) (*slog.Logger, error) {
 	}
 
 	return slog.New(
-		slog.NewTextHandler(
-			os.Stderr, //nolint:forbidigo
-			&slog.HandlerOptions{
-				Level: ll,
-			},
+		tracing.NewSlogHandler(
+			slog.NewTextHandler(
+				os.Stderr, //nolint:forbidigo
+				&slog.HandlerOptions{
+					Level: ll,
+				},
+			),
 		),
 	), nil
 }

--- a/cmd/store/store.go
+++ b/cmd/store/store.go
@@ -85,11 +85,13 @@ func New() *cobra.Command { //nolint:funlen
 			}
 
 			log := slog.New(
-				slog.NewTextHandler(
-					os.Stderr, //nolint:forbidigo
-					&slog.HandlerOptions{
-						Level: ll,
-					},
+				tracing.NewSlogHandler(
+					slog.NewTextHandler(
+						os.Stderr, //nolint:forbidigo
+						&slog.HandlerOptions{
+							Level: ll,
+						},
+					),
 				),
 			)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -112,11 +112,12 @@ func (a *APIServer) processBuildRequest(w http.ResponseWriter, r *http.Request, 
 		slog.Any("dependencies", req.Dependencies),
 	)
 
-	log.Debug("processing", "request", req.String())
+	ctx := r.Context()
+
+	log.DebugContext(ctx, "processing", "request", req.String())
 
 	resp := api.BuildResponse{}
 
-	ctx := r.Context()
 	if req.NoCache {
 		ctx = api.WithNoCache(ctx, true)
 	}
@@ -134,15 +135,15 @@ func (a *APIServer) processBuildRequest(w http.ResponseWriter, r *http.Request, 
 		a.addCacheHeader(w, artifact)
 		w.WriteHeader(http.StatusOK)
 		resp.Artifact = artifact
-		log.Debug("returning", "response", resp.String())
+		log.DebugContext(ctx, "returning", "response", resp.String())
 	case errors.Is(err, k6build.ErrInvalidParameters):
 		w.WriteHeader(http.StatusOK)
 		resp.Error = k6build.NewWrappedError(api.ErrCannotSatisfy, err)
-		log.Info(resp.Error.Error())
+		log.InfoContext(ctx, resp.Error.Error())
 	default:
 		resp.Error = k6build.NewWrappedError(api.ErrBuildFailed, err)
 		w.WriteHeader(http.StatusInternalServerError)
-		log.Error(resp.Error.Error())
+		log.ErrorContext(ctx, resp.Error.Error())
 	}
 
 	_ = json.NewEncoder(w).Encode(resp) //nolint:errchkjson
@@ -177,10 +178,12 @@ func (a *APIServer) Resolve(w http.ResponseWriter, r *http.Request) {
 		slog.Any("dependencies", req.Dependencies),
 	)
 
-	log.Debug("processing", "request", req.String())
+	ctx := r.Context()
+
+	log.DebugContext(ctx, "processing", "request", req.String())
 
 	deps, err := a.srv.Resolve(
-		r.Context(),
+		ctx,
 		resolveK6ModPath(req.K6ModPath),
 		req.K6Constrains,
 		req.Dependencies,
@@ -190,15 +193,15 @@ func (a *APIServer) Resolve(w http.ResponseWriter, r *http.Request) {
 	case err == nil:
 		resp.Dependencies = deps
 		w.WriteHeader(http.StatusOK)
-		log.Debug("returning", "response", resp.String())
+		log.DebugContext(ctx, "returning", "response", resp.String())
 	case errors.Is(err, k6build.ErrInvalidParameters):
 		w.WriteHeader(http.StatusOK)
 		resp.Error = k6build.NewWrappedError(api.ErrCannotSatisfy, err)
-		log.Info(resp.Error.Error())
+		log.InfoContext(ctx, resp.Error.Error())
 	default:
 		resp.Error = k6build.NewWrappedError(api.ErrResolveFailed, err)
 		w.WriteHeader(http.StatusInternalServerError)
-		log.Error(resp.Error.Error())
+		log.ErrorContext(ctx, resp.Error.Error())
 	}
 
 	_ = json.NewEncoder(w).Encode(resp) //nolint:errchkjson

--- a/pkg/tracing/slog.go
+++ b/pkg/tracing/slog.go
@@ -1,0 +1,47 @@
+package tracing
+
+import (
+	"context"
+	"log/slog"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// SlogHandler wraps a slog.Handler and, when a record is emitted with a context
+// carrying an active span, adds "trace_id" and "span_id" attributes. This
+// correlates log lines with traces so a log line can be linked to its trace.
+type SlogHandler struct {
+	inner slog.Handler
+}
+
+// NewSlogHandler wraps inner with trace/span correlation.
+func NewSlogHandler(inner slog.Handler) *SlogHandler {
+	return &SlogHandler{inner: inner}
+}
+
+// Enabled implements slog.Handler.
+func (h *SlogHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+// Handle implements slog.Handler, injecting trace_id/span_id from ctx when present.
+func (h *SlogHandler) Handle(ctx context.Context, record slog.Record) error {
+	if sc := trace.SpanContextFromContext(ctx); sc.IsValid() {
+		record.AddAttrs(
+			slog.String("trace_id", sc.TraceID().String()),
+			slog.String("span_id", sc.SpanID().String()),
+		)
+	}
+	return h.inner.Handle(ctx, record)
+}
+
+// WithAttrs implements slog.Handler, preserving the wrapper so correlation
+// survives loggers derived via Logger.With.
+func (h *SlogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &SlogHandler{inner: h.inner.WithAttrs(attrs)}
+}
+
+// WithGroup implements slog.Handler, preserving the wrapper.
+func (h *SlogHandler) WithGroup(name string) slog.Handler {
+	return &SlogHandler{inner: h.inner.WithGroup(name)}
+}

--- a/pkg/tracing/slog_test.go
+++ b/pkg/tracing/slog_test.go
@@ -1,0 +1,71 @@
+package tracing
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestSlogHandlerInjectsTraceContext(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	log := slog.New(NewSlogHandler(slog.NewTextHandler(buf, nil)))
+
+	traceID, _ := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
+	spanID, _ := trace.SpanIDFromHex("0102030405060708")
+	ctx := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: traceID,
+		SpanID:  spanID,
+	}))
+
+	log.InfoContext(ctx, "hello")
+
+	out := buf.String()
+	if !strings.Contains(out, "trace_id="+traceID.String()) {
+		t.Errorf("expected trace_id in log output, got: %s", out)
+	}
+	if !strings.Contains(out, "span_id="+spanID.String()) {
+		t.Errorf("expected span_id in log output, got: %s", out)
+	}
+}
+
+func TestSlogHandlerNoSpanContext(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	log := slog.New(NewSlogHandler(slog.NewTextHandler(buf, nil)))
+
+	log.Info("hello")
+
+	out := buf.String()
+	if strings.Contains(out, "trace_id") {
+		t.Errorf("did not expect trace_id without an active span, got: %s", out)
+	}
+}
+
+func TestSlogHandlerWithAttrsPreservesCorrelation(t *testing.T) {
+	t.Parallel()
+
+	buf := &bytes.Buffer{}
+	// Logger.With derives a handler via WithAttrs; correlation must survive.
+	log := slog.New(NewSlogHandler(slog.NewTextHandler(buf, nil))).With("platform", "linux/amd64")
+
+	traceID, _ := trace.TraceIDFromHex("0102030405060708090a0b0c0d0e0f10")
+	spanID, _ := trace.SpanIDFromHex("0102030405060708")
+	ctx := trace.ContextWithSpanContext(context.Background(), trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: traceID,
+		SpanID:  spanID,
+	}))
+
+	log.InfoContext(ctx, "hello")
+
+	out := buf.String()
+	if !strings.Contains(out, "trace_id="+traceID.String()) {
+		t.Errorf("expected trace_id to survive With(), got: %s", out)
+	}
+}


### PR DESCRIPTION
## What

Adds trace↔log correlation so a log line can be linked back to its trace. Until now the logger and tracer were independent — spans were exported, but log lines carried no `trace_id`, so there was no way to jump from a log line to its trace.

## How

- New `tracing.SlogHandler` wraps any `slog.Handler` and, when a record is emitted with a context carrying an active span, adds `trace_id` and `span_id` attributes. `WithAttrs`/`WithGroup` are overridden so correlation survives loggers derived via `logger.With(...)`.
- Wired into the server (`getLogger`) and store loggers.
- The build/resolve request handlers now use the `*Context` log variants (`DebugContext`/`InfoContext`/`ErrorContext`) so the `otelhttp` server span in the request context is picked up.

## Result

Log lines emitted during a request now include `trace_id=<...> span_id=<...>`, e.g.:

```
level=DEBUG msg=processing request="..." platform=linux/amd64 k6=v1.8.0 trace_id=abc123... span_id=def456...
```

## Tests

`pkg/tracing/slog_test.go` covers: injection when a span is present, no attrs when absent, and survival across `Logger.With(...)`. `go build`, `go vet`, and existing server tests pass.

## Notes

- Build-progress lines from k6foundry ("Building k6", etc.) are emitted by that library and are out of scope here; the request-level lines now carry the `trace_id`, which is sufficient to locate the full trace.