### PR TITLE
feat: support building k6 against Go pseudo-versions

### DIFF
--- a/pkg/builder/builder.go
+++ b/pkg/builder/builder.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/grafana/k6foundry"
 
 	"github.com/grafana/k6build"
@@ -332,20 +333,25 @@ func (b *Builder) resolveDependencies(
 
 	resolved := map[string]catalog.Module{}
 
-	// check if it is a semver of the form v0.0.0+<build>
-	// if it is, we don't check with the catalog, but instead we use
-	// the build metadata as version when building this module
-	var k6Mod catalog.Module
-	buildMetadata, err := hasBuildMetadata(k6Constrains)
+	// A pseudo-version or a v0.0.0+<commit> build-metadata semver both reference a
+	// commit that is not in the catalog, so we build straight from the commit.
+	commit, err := pseudoVersionCommit(k6Constrains)
 	if err != nil {
 		return nil, k6build.NewWrappedError(k6build.ErrInvalidParameters, err)
 	}
-	if buildMetadata != "" {
+	if commit == "" {
+		commit, err = hasBuildMetadata(k6Constrains)
+		if err != nil {
+			return nil, k6build.NewWrappedError(k6build.ErrInvalidParameters, err)
+		}
+	}
+
+	var k6Mod catalog.Module
+	if commit != "" {
 		if !b.opts.AllowBuildSemvers {
 			return nil, k6build.NewWrappedError(k6build.ErrInvalidParameters, ErrBuildSemverNotAllowed)
 		}
-		// use a semantic version for the build metadata
-		k6Mod = catalog.Module{Path: k6ModPath, Version: "v0.0.0+" + buildMetadata}
+		k6Mod = catalog.Module{Path: k6ModPath, Version: "v0.0.0+" + commit}
 	} else {
 		k6Mod, err = ctlg.Resolve(ctx, catalog.Dependency{Name: k6DependencyName, Constrains: k6Constrains})
 		if err != nil {
@@ -363,6 +369,47 @@ func (b *Builder) resolveDependencies(
 	}
 
 	return resolved, nil
+}
+
+// pseudoVersionCommit returns the commit referenced by a Go pseudo-version such as
+// v1.7.2-0.20260603164357-0c72fa6d4511 (here 0c72fa6d4511), or "" if the constrain
+// is not a pseudo-version. Only an exact match is allowed, optionally with a "=".
+func pseudoVersionCommit(constrain string) (string, error) {
+	// strip a leading comparison operator so the rest parses as a plain semver
+	ver := strings.TrimLeft(constrain, "=~><^! ")
+	op := strings.TrimSpace(constrain[:len(constrain)-len(ver)])
+
+	v, err := semver.NewVersion(strings.TrimSpace(ver))
+	if err != nil {
+		return "", nil //nolint:nilerr
+	}
+
+	pre := v.Prerelease()
+	if pre == "" {
+		return "", nil
+	}
+
+	// the commit is in the last dot-separated segment, as <14-digit-timestamp>-<commit>
+	segments := strings.Split(pre, ".")
+	timestamp, commit, found := strings.Cut(segments[len(segments)-1], "-")
+	if !found || commit == "" {
+		return "", nil
+	}
+
+	if len(timestamp) != 14 {
+		return "", nil
+	}
+	for _, c := range timestamp {
+		if c < '0' || c > '9' {
+			return "", nil
+		}
+	}
+
+	if op != "" && op != "=" {
+		return "", fmt.Errorf("only exact match is allowed for pseudo-versions")
+	}
+
+	return commit, nil
 }
 
 // hasBuildMetadata checks if the constrain references a version with a build metadata.

--- a/pkg/builder/pseudo_version_test.go
+++ b/pkg/builder/pseudo_version_test.go
@@ -1,0 +1,284 @@
+package builder
+
+import (
+	"context"
+	"errors"
+	"io"
+	"path/filepath"
+	"testing"
+
+	"github.com/grafana/k6foundry"
+
+	"github.com/grafana/k6build"
+	"github.com/grafana/k6build/pkg/store/file"
+)
+
+func TestPseudoVersionCommit(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		title     string
+		constrain string
+		expect    string
+		expectErr bool
+	}{
+		{
+			title:     "pseudo-version based on a tagged release",
+			constrain: "v1.7.2-0.20260603164357-0c72fa6d4511",
+			expect:    "0c72fa6d4511",
+		},
+		{
+			title:     "pseudo-version with no base version",
+			constrain: "v0.0.0-20260603164357-0c72fa6d4511",
+			expect:    "0c72fa6d4511",
+		},
+		{
+			title:     "pseudo-version based on a pre-release",
+			constrain: "v1.7.2-rc.0.20260603164357-0c72fa6d4511",
+			expect:    "0c72fa6d4511",
+		},
+		{
+			title:     "pseudo-version with a leading = operator",
+			constrain: "=v1.7.2-0.20260603164357-0c72fa6d4511",
+			expect:    "0c72fa6d4511",
+		},
+		{
+			title:     "pseudo-version with a non-exact operator",
+			constrain: ">v1.7.2-0.20260603164357-0c72fa6d4511",
+			expectErr: true,
+		},
+		{
+			title:     "exact semver",
+			constrain: "v1.7.2",
+			expect:    "",
+		},
+		{
+			title:     "semver range",
+			constrain: ">v1.7.2",
+			expect:    "",
+		},
+		{
+			title:     "wildcard",
+			constrain: "*",
+			expect:    "",
+		},
+		{
+			title:     "build metadata semver",
+			constrain: "v0.0.0+0c72fa6d4511",
+			expect:    "",
+		},
+		{
+			title:     "plain pre-release (not a pseudo-version)",
+			constrain: "v1.0.0-rc1",
+			expect:    "",
+		},
+		{
+			title:     "empty",
+			constrain: "",
+			expect:    "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
+			commit, err := pseudoVersionCommit(tc.constrain)
+			if tc.expectErr {
+				if err == nil {
+					t.Fatalf("pseudoVersionCommit(%q) expected an error, got nil", tc.constrain)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("pseudoVersionCommit(%q) unexpected error: %v", tc.constrain, err)
+			}
+			if commit != tc.expect {
+				t.Fatalf("pseudoVersionCommit(%q) = %q, want %q", tc.constrain, commit, tc.expect)
+			}
+		})
+	}
+}
+
+// recordingFoundry captures the arguments passed to Build so tests can assert
+// what the builder forwarded to the foundry.
+type recordingFoundry struct {
+	opts      k6foundry.NativeFoundryOpts
+	k6Version string
+	mods      []k6foundry.Module
+}
+
+func (m *recordingFoundry) Build(
+	_ context.Context,
+	platform k6foundry.Platform,
+	k6Version string,
+	mods []k6foundry.Module,
+	_ []k6foundry.Module,
+	_ []string,
+	_ io.Writer,
+) (*k6foundry.BuildInfo, error) {
+	m.k6Version = k6Version
+	m.mods = mods
+
+	modVersions := make(map[string]string, len(mods))
+	for _, mod := range mods {
+		modVersions[mod.Path] = mod.Version
+	}
+	return &k6foundry.BuildInfo{
+		Platform:    platform.String(),
+		ModVersions: modVersions,
+	}, nil
+}
+
+// newRecordingBuilder creates a builder whose foundry records the build arguments.
+// AllowBuildSemvers is configurable since pseudo-versions, like v0.0.0+<commit>
+// build-metadata versions, build an arbitrary commit and are gated by it.
+func newRecordingBuilder(t *testing.T, k6ModPath string, allowBuildSemvers bool) (*Builder, *recordingFoundry) {
+	t.Helper()
+
+	store, err := file.NewFileStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("creating temporary object store %v", err)
+	}
+
+	rec := &recordingFoundry{}
+	factory := FoundryFactoryFunction(func(_ context.Context, opts k6foundry.NativeFoundryOpts) (k6foundry.Foundry, error) {
+		rec.opts = opts
+		return rec, nil
+	})
+
+	catalog := "catalog.json"
+	if k6ModPath == "go.k6.io/k6/v2" {
+		catalog = "catalog-v2.json"
+	}
+
+	buildsrv, err := New(t.Context(), Config{
+		Opts:    Opts{AllowBuildSemvers: allowBuildSemvers},
+		Catalog: filepath.Join("testdata", catalog),
+		Store:   store,
+		Foundry: factory,
+	})
+	if err != nil {
+		t.Fatalf("creating builder %v", err)
+	}
+
+	return buildsrv, rec
+}
+
+func TestResolvePseudoVersion(t *testing.T) {
+	t.Parallel()
+
+	// the pseudo-version is normalized to v0.0.0+<commit>, the same form used for
+	// build-metadata semvers.
+	const (
+		pseudo  = "v1.7.2-0.20260603164357-0c72fa6d4511"
+		resolve = "v0.0.0+0c72fa6d4511"
+	)
+
+	buildsrv, _ := newRecordingBuilder(t, defaultK6ModPath, true)
+
+	resolved, err := buildsrv.Resolve(t.Context(), defaultK6ModPath, pseudo, []k6build.Dependency{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := resolved["k6"]; got != resolve {
+		t.Fatalf("expected k6 version %q, got %q", resolve, got)
+	}
+}
+
+func TestResolvePseudoVersionWithOperator(t *testing.T) {
+	t.Parallel()
+
+	const (
+		pseudo  = "=v1.7.2-0.20260603164357-0c72fa6d4511"
+		resolve = "v0.0.0+0c72fa6d4511"
+	)
+
+	buildsrv, _ := newRecordingBuilder(t, defaultK6ModPath, true)
+
+	resolved, err := buildsrv.Resolve(t.Context(), defaultK6ModPath, pseudo, []k6build.Dependency{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := resolved["k6"]; got != resolve {
+		t.Fatalf("expected k6 version %q, got %q", resolve, got)
+	}
+}
+
+func TestBuildPseudoVersion(t *testing.T) {
+	t.Parallel()
+
+	const (
+		pseudo = "v1.7.2-0.20260603164357-0c72fa6d4511"
+		commit = "0c72fa6d4511"
+	)
+
+	buildsrv, rec := newRecordingBuilder(t, defaultK6ModPath, true)
+
+	artifact, err := buildsrv.Build(t.Context(), platform(), defaultK6ModPath, pseudo, []k6build.Dependency{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// the artifact reports the normalized v0.0.0+<commit> version
+	if got := artifact.Dependencies["k6"]; got != "v0.0.0+"+commit {
+		t.Fatalf("expected k6 version %q in artifact, got %q", "v0.0.0+"+commit, got)
+	}
+
+	// the foundry receives the bare commit as the build version
+	if rec.k6Version != commit {
+		t.Fatalf("expected foundry to receive k6 version %q, got %q", commit, rec.k6Version)
+	}
+}
+
+func TestBuildPseudoVersionV2(t *testing.T) {
+	t.Parallel()
+
+	const (
+		pseudo    = "v2.0.0-0.20260603164357-0c72fa6d4511"
+		commit    = "0c72fa6d4511"
+		k6ModPath = "go.k6.io/k6/v2"
+	)
+
+	buildsrv, rec := newRecordingBuilder(t, k6ModPath, true)
+
+	artifact, err := buildsrv.Build(t.Context(), platform(), k6ModPath, pseudo, []k6build.Dependency{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := artifact.Dependencies["k6"]; got != "v0.0.0+"+commit {
+		t.Fatalf("expected k6 version %q in artifact, got %q", "v0.0.0+"+commit, got)
+	}
+
+	if rec.k6Version != commit {
+		t.Fatalf("expected foundry to receive k6 version %q, got %q", commit, rec.k6Version)
+	}
+
+	// the major version suffix must be derived from the v2 module path so the
+	// foundry uses the correct import path for the git SHA.
+	if rec.opts.K6MajorVersion != "v2" {
+		t.Fatalf("expected K6MajorVersion %q, got %q", "v2", rec.opts.K6MajorVersion)
+	}
+}
+
+// TestBuildPseudoVersionGatedByAllowBuildSemvers ensures that, like v0.0.0+<commit>
+// build-metadata versions, pseudo-versions are rejected when AllowBuildSemvers is
+// false (the default) since they build an arbitrary commit.
+func TestBuildPseudoVersionGatedByAllowBuildSemvers(t *testing.T) {
+	t.Parallel()
+
+	const pseudo = "v1.7.2-0.20260603164357-0c72fa6d4511"
+
+	buildsrv, _ := newRecordingBuilder(t, defaultK6ModPath, false)
+
+	_, err := buildsrv.Build(t.Context(), platform(), defaultK6ModPath, pseudo, []k6build.Dependency{})
+	if !errors.Is(err, k6build.ErrInvalidParameters) {
+		t.Fatalf("expected ErrInvalidParameters, got %v", err)
+	}
+	if !errors.Is(err, ErrBuildSemverNotAllowed) {
+		t.Fatalf("expected ErrBuildSemverNotAllowed, got %v", err)
+	}
+}


### PR DESCRIPTION
## What

Adds support for building k6 against Go pseudo-versions like
`v1.7.2-0.20260603164357-0c72fa6d4511`.

## Why

Pseudo-versions reference a specific commit and are not present in the
catalog, so a request specifying one previously failed: the version
matched the build-metadata regex and was rejected with *"version with
build metadata must start with v0.0.0"*. This makes it possible to build
k6 from an untagged commit using the pseudo-version Go already produces.

## How

`pseudoVersionCommit` extracts the commit from the last dot-separated
segment of the semver pre-release (`<14-digit-timestamp>-<commit>`), using
`Masterminds/semver` to parse and plain string splitting to pull out the
commit — no new dependency, no regexp. It accepts an optional leading `=`
and rejects non-exact operators.

In `resolveDependencies`, the extracted commit is fed through the same
`v0.0.0+<commit>` machinery used for build-metadata semvers, so the
foundry receives the bare commit for `go get`. Module-path handling still
derives the major-version suffix (e.g. `v2` for `go.k6.io/k6/v2`).

## Notes / behaviour change

Pseudo-versions are gated by `AllowBuildSemvers`, consistent with
`v0.0.0+<commit>` versions, since both build an arbitrary commit.

## Tests

The version-handling code had no test coverage; this PR adds:

- `TestPseudoVersionCommit` — commit extraction across pseudo-version
  shapes (tagged base, no base, pre-release base, `=` prefix) and
  rejection of plain semvers, ranges, wildcards, build-metadata semvers
  and non-exact operators.
- `TestResolvePseudoVersion` / `...WithOperator` — normalization to
  `v0.0.0+<commit>`.
- `TestBuildPseudoVersion` / `...V2` — artifact version, the bare commit
  reaching the foundry, and v2 major-version routing.
- `TestBuildPseudoVersionGatedByAllowBuildSemvers` — the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)