### PR TITLE
Add Release workflow (tag, build image, cut release)

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -11,6 +11,10 @@ on:
 
 jobs:
   checks:
+    # Matches the permissions the reusable workflow declares for itself, so it
+    # keeps working if the org default GITHUB_TOKEN is restricted to read-only.
+    permissions:
+      contents: read
     uses: grafana/k6-ci/.github/workflows/all.yml@143ec80c1678ae96a54b82389ea862d4748c27e1 # main
     with:
       skip-extension-testing: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,47 @@
+name: publish
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: grafana/k6build
+
+jobs:
+  publish-images:
+    runs-on: ubuntu-x64
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+      - name: Set up Docker buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        with:
+          version: v0.9.1
+          cache-binary: false
+      - name: Log into ghcr.io
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push image
+        run: |
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+             IMAGE_VERSION=$GITHUB_REF_NAME
+          else
+             IMAGE_VERSION='latest'
+          fi
+          IMAGE_TAG="$REGISTRY/$IMAGE_NAME:${IMAGE_VERSION}"
+          docker buildx build -t $IMAGE_TAG --platform=linux/amd64,linux/arm64 --push .

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,11 +3,6 @@ name: Release
 # Cut a tagged release: tag the current main HEAD, create a GitHub release with
 # auto-generated notes, and build & push the multi-arch image for that version.
 #
-# This is generic release plumbing — nothing cloud-specific — so it lives here in
-# the public repo. It can be run manually by maintainers, or dispatched by the
-# k6-cloud-backend-release pipeline (which passes an explicit `tag` it has already
-# computed).
-#
 # It deliberately does NOT rely on the `publish` workflow firing off the tag push:
 # a tag created by the default GITHUB_TOKEN does not trigger other workflows, so
 # this job builds and pushes the image itself. The image is pushed BEFORE the

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,47 +1,121 @@
-name: publish
+name: Release
+
+# Cut a tagged release: tag the current main HEAD, create a GitHub release with
+# auto-generated notes, and build & push the multi-arch image for that version.
+#
+# This is generic release plumbing — nothing cloud-specific — so it lives here in
+# the public repo. It can be run manually by maintainers, or dispatched by the
+# k6-cloud-backend-release pipeline (which passes an explicit `tag` it has already
+# computed).
+#
+# It deliberately does NOT rely on the `publish` workflow firing off the tag push:
+# a tag created by the default GITHUB_TOKEN does not trigger other workflows, so
+# this job builds and pushes the image itself. The image is pushed BEFORE the
+# release is created, so a published release always has a corresponding image.
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - v*
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Version to release (e.g. v0.7.0). If empty, the latest release is minor-bumped (vX.Y.Z -> vX.(Y+1).0)."
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
 
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: grafana/k6build
 
 jobs:
-  publish-images:
+  cut-release:
     runs-on: ubuntu-x64
     permissions:
-      contents: read
-      packages: write
+      contents: write   # create the tag and the GitHub release
+      packages: write   # push the image to GHCR
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Resolve release version
+        id: version
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPLICIT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          latest=$(gh release view --json tagName --jq .tagName)
+          echo "Latest release: $latest"
+
+          # Idempotency: skip if main's HEAD is already the tagged commit.
+          head_sha=$(git rev-parse HEAD)
+          latest_sha=$(git rev-list -n 1 "$latest")
+          echo "main HEAD:         $head_sha"
+          echo "latest tag commit: $latest_sha"
+          if [ "$head_sha" = "$latest_sha" ]; then
+            echo "No new commits since $latest — nothing to release."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -n "$EXPLICIT_TAG" ]; then
+            next="$EXPLICIT_TAG"
+          else
+            # Semver minor auto-bump: vX.Y.Z -> vX.(Y+1).0
+            ver="${latest#v}"
+            IFS=. read -r major minor _patch <<< "$ver"
+            next="v${major}.$((minor + 1)).0"
+          fi
+          echo "Releasing: $next"
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+          echo "tag=$next" >> "$GITHUB_OUTPUT"
+
       - name: Set up QEMU
+        if: ${{ steps.version.outputs.skip != 'true' }}
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
       - name: Set up Docker buildx
+        if: ${{ steps.version.outputs.skip != 'true' }}
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
         with:
           version: v0.9.1
           cache-binary: false
+
       - name: Log into ghcr.io
+        if: ${{ steps.version.outputs.skip != 'true' }}
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push image
+        if: ${{ steps.version.outputs.skip != 'true' }}
+        env:
+          IMAGE_VERSION: ${{ steps.version.outputs.tag }}
         run: |
-          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
-             IMAGE_VERSION=$GITHUB_REF_NAME
-          else
-             IMAGE_VERSION='latest'
-          fi
+          set -euo pipefail
           IMAGE_TAG="$REGISTRY/$IMAGE_NAME:${IMAGE_VERSION}"
-          docker buildx build -t $IMAGE_TAG --platform=linux/amd64,linux/arm64 --push .
+          docker buildx build -t "$IMAGE_TAG" --platform=linux/amd64,linux/arm64 --push .
+
+      - name: Create release with auto-generated notes
+        if: ${{ steps.version.outputs.skip != 'true' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Tags the current HEAD and cuts the release in one call; --generate-notes
+          # builds the changelog from commits since the previous release.
+          gh release create "$TAG" \
+            --target "$GITHUB_SHA" \
+            --title "$TAG" \
+            --generate-notes \
+            --latest

--- a/README.md
+++ b/README.md
@@ -67,32 +67,50 @@ TODO: use [k6-operator](https://github.com/grafana/k6-operator) for running the 
 
 ## Releasing
 
-The release process for k6build involves tagging, building a Docker image, and creating a GitHub release.
+The recommended way to cut a release is the [`Release` workflow](.github/workflows/release.yaml). In a
+single run it tags `main`'s HEAD, builds and pushes the multi-architecture (`linux/amd64`,
+`linux/arm64`) Docker image to `ghcr.io/grafana/k6build:<tag>`, and creates a GitHub release with
+auto-generated notes.
 
-### 1. Create and push a tag
+### Cut a release from GitHub Actions (recommended)
 
-Create an annotated tag following semantic versioning with a `v` prefix and push it:
+Maintainers can run it from the UI or the CLI:
 
-```bash
-git tag -a v0.5.0 -m "Release v0.5.0"
-git push origin v0.5.0
-```
+- **UI:** go to **Actions → Release → Run workflow**, select the `main` branch, and either leave
+  **tag** empty to minor-bump the latest release (`vX.Y.Z` → `vX.(Y+1).0`) or set an explicit version
+  such as `v0.7.0`.
+- **CLI:**
 
-### 2. Docker image build (automatic)
+  ```bash
+  # minor auto-bump of the latest release
+  gh workflow run release.yaml --repo grafana/k6build --ref main
 
-Pushing the tag triggers the [publish workflow](.github/workflows/release.yaml), which builds and pushes a multi-architecture (`linux/amd64`, `linux/arm64`) Docker image to `ghcr.io/grafana/k6build:<tag>`.
+  # explicit version
+  gh workflow run release.yaml --repo grafana/k6build --ref main -f tag=v0.7.0
+  ```
 
-Pushes to `main` (without a tag) publish the image as `ghcr.io/grafana/k6build:latest`.
+The workflow is idempotent: if `main` has no new commits since the latest tag it does nothing. The
+image is pushed before the release is cut, so a published release always has a matching image. This is
+also exactly how the k6-cloud backend release pipeline releases k6build, so a manual run and a pipeline
+run do the same thing.
 
-### 3. Create a GitHub release (manual)
+### Manual release (fallback)
 
-After the CI workflow completes, manually create a GitHub release for the tag:
+If you need to release without the workflow:
 
-1. Go to the repository's **Releases** page.
-2. Click **Draft a new release**.
-3. Select the tag you just pushed.
-4. Add release notes describing the changes.
-5. Publish the release.
+1. Create and push an annotated tag following semantic versioning with a `v` prefix:
+
+   ```bash
+   git tag -a v0.7.0 -m "Release v0.7.0"
+   git push origin v0.7.0
+   ```
+
+   Pushing the tag triggers the [publish workflow](.github/workflows/publish.yaml), which builds and
+   pushes the multi-architecture image to `ghcr.io/grafana/k6build:<tag>`. (Pushes to `main` without a
+   tag publish `ghcr.io/grafana/k6build:latest`.)
+
+2. Create a GitHub release for the tag from the repository's **Releases** page: **Draft a new release**
+   → select the tag → add release notes → **Publish release**.
 
 <!-- #region cli -->
 # k6build


### PR DESCRIPTION
## What

Adds a `Release` workflow that cuts a release in one run: it resolves the next version (semver minor auto-bump of the latest release, or an explicit `tag` input), builds and pushes the multi-arch (`linux/amd64`, `linux/arm64`) image to `ghcr.io/grafana/k6build:<tag>`, then creates the GitHub release with auto-generated notes.

## Details

- **Image before release:** the image is pushed before the release is cut, so a published release always has a matching image.
- **Idempotent:** no-ops when `main` has no new commits since the latest tag (all build/release steps are gated on the resolve step).
- **Self-contained:** it does *not* rely on the tag push cascading into another workflow (a tag created by `GITHUB_TOKEN` does not trigger other workflows), so it builds and pushes the image itself.
- **Usable two ways:** manually by maintainers (**Actions → Release → Run workflow**, or `gh workflow run release.yaml`), and dispatched by the k6-cloud backend release pipeline.

## Preserving the existing publish workflow

The previous workflow (`name: publish`, built `latest` on main pushes and the versioned image on tag pushes) is renamed `release.yaml` → `publish.yaml`, unchanged otherwise. The new `Release` workflow takes the `release.yaml` filename.

The README "Releasing" section now documents the workflow as the recommended path, with the manual tag-and-release flow as a fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)